### PR TITLE
[Update] 1.18.2

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -6,7 +6,7 @@
         Programmer, modeller, mapper, painter
              Author of Demoman The Pirate
          One of two creators of Floral Defence
-	      
+
       And notoriously famous for creating plugins
       with terrible code and then abandoning them.
 
@@ -30,7 +30,7 @@
 
 
 
- 
+
  I'm not sure how long FF2 (or TF2 in general) is going to
 last, but I would hate to see this plugin go, it's one of
 my all time favorite gamemodes. I just love the concept of
@@ -80,9 +80,9 @@ last time or to encourage others to do the same.
 #define FORK_MINOR_REVISION "18"
 #define FORK_STABLE_REVISION "2"
 #define FORK_SUB_REVISION "Unofficial"
-#define FORK_DEV_REVISION "Build"
+//#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."007"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -108,12 +108,12 @@ last time or to encourage others to do the same.
 #define PREF_DUO	2
 #define PREF_BOSS	3
 
-#define STAT_WINS		4
-#define STAT_LOSSES		5
-#define STAT_KILLS		6
-#define STAT_DEATHS		7
-#define STAT_SLAINS		8
-#define STAT_MVPS		9
+#define STAT_WINS	4
+#define STAT_LOSSES	5
+#define STAT_KILLS	6
+#define STAT_DEATHS	7
+#define STAT_SLAINS	8
+#define STAT_MVPS	9
 
 #define HEALTHBAR_CLASS "monster_resource"
 #define HEALTHBAR_PROPERTY "m_iBossHealthPercentageByte"
@@ -745,6 +745,7 @@ stock void FindVersionData(Handle panel, int versionIndex)
 		{
 			DrawPanelText(panel, "1) [Gameplay] Fixed Health HUD values being higher for most players (Batfoxkid)");
 			DrawPanelText(panel, "2) [Gameplay] Ullapool Caber detonations message doesn't show for one-shot Cabers (Batfoxkid)");
+			DrawPanelText(panel, "3) [Gameplay] Fixed boss healing (again) (Batfoxkid)");
 		}
 		case 143:  //1.18.1
 		{
@@ -10868,7 +10869,7 @@ public Action OnPlayerHealed(Handle event, const char[] name, bool dontBroadcast
 	{
 		int boss = GetBossIndex(client);
 		int health = BossHealth[boss];
-		int totalhealth = BossHealthMax[boss]*BossLivesMax[boss];
+		int totalhealth = BossHealthMax[boss]*BossLives[boss];
 
 		/*int maxlives = BossLivesMax[boss];
 		int maxhealth = BossHealthMax[boss];
@@ -10891,6 +10892,7 @@ public Action OnPlayerHealed(Handle event, const char[] name, bool dontBroadcast
 				health = totalhealth;
 			}
 		}
+		BossHealth[boss] = health;
 		return Plugin_Continue;
 	}
 
@@ -10998,8 +11000,14 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 		foundDmgCustom=true;
 	}
 
-	if((attacker<=0 || client==attacker) && IsBoss(client) && !(FF2flags[client] & FF2FLAG_ALLOW_BOSS_ROCKETJUMPING))
+	if((attacker<=0 || client==attacker) && IsBoss(client) && damagetype & DMG_FALL)
+	{
 		return Plugin_Handled;
+	}
+	else if((attacker<=0 || client==attacker) && IsBoss(client) && !(FF2flags[client] & FF2FLAG_ALLOW_BOSS_ROCKETJUMPING))
+	{
+		return Plugin_Handled;
+	}
 
 	if(TF2_IsPlayerInCondition(client, TFCond_Ubercharged))
 		return Plugin_Continue;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."004"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -137,6 +137,7 @@ last time or to encourage others to do the same.
 
 #if defined _steamtools_included
 bool steamtools = false;
+bool EnabledDesc = false;
 #endif
 
 #if defined _tf2attributes_included
@@ -322,7 +323,6 @@ Handle healthHUD;
 
 bool Enabled = true;
 bool Enabled2 = true;
-bool EnabledDesc = false;
 int PointDelay = 6;
 int PointTime = 45;
 float Announce = 120.0;
@@ -2824,7 +2824,6 @@ public void EnableFF2()
 {
 	Enabled = true;
 	Enabled2 = true;
-	EnabledDesc = true;
 
 	//Cache cvars
 	SetConVarString(FindConVar("ff2_version"), PLUGIN_VERSION);
@@ -2899,6 +2898,7 @@ public void EnableFF2()
 	FindHealthBar();
 
 	#if defined _steamtools_included
+	EnabledDesc = true;
 	if(steamtools && GetConVarBool(cvarSteamTools))
 	{
 		char gameDesc[64];
@@ -2974,9 +2974,9 @@ public void DisableFF2()
 	{
 		Steam_SetGameDescription("Team Fortress");
 	}
+	EnabledDesc = false;
 	#endif
 
-	EnabledDesc = false;
 	changeGamemode = 0;
 }
 
@@ -3834,9 +3834,10 @@ public Action OnRoundStart(Handle event, const char[] name, bool dontBroadcast)
 		{
 			Steam_SetGameDescription("Team Fortress");
 		}
-		#endif
-		Enabled2 = false;
 		EnabledDesc = false;
+		#endif
+
+		Enabled2 = false;
 	}
 
 	Enabled = Enabled2;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."047"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."048"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -8051,31 +8051,35 @@ public Action OnUberDeployed(Handle event, const char[] name, bool dontBroadcast
 
 public Action Timer_Uber(Handle timer, any medigunid)
 {
-	int medigun=EntRefToEntIndex(medigunid);
+	int medigun = EntRefToEntIndex(medigunid);
 	if(medigun && IsValidEntity(medigun) && CheckRoundState()==1)
 	{
-		int client=GetEntPropEnt(medigun, Prop_Send, "m_hOwnerEntity");
-		float charge=GetEntPropFloat(medigun, Prop_Send, "m_flChargeLevel");
+		int client = GetEntPropEnt(medigun, Prop_Send, "m_hOwnerEntity");
+		float charge = GetEntPropFloat(medigun, Prop_Send, "m_flChargeLevel");
 		if(IsValidClient(client, false) && IsPlayerAlive(client) && GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon")==medigun)
 		{
-			int target=GetHealingTarget(client);
-			if(charge>0.05)
+			int target = GetHealingTarget(client);
+			if(charge > 0.05)
 			{
 				TF2_AddCondition(client, TFCond_HalloweenCritCandy, 0.5);
 				if(IsValidClient(target, false) && IsPlayerAlive(target))
 				{
 					TF2_AddCondition(target, TFCond_HalloweenCritCandy, 0.5);
-					uberTarget[client]=target;
+					uberTarget[client] = target;
 				}
 				else
 				{
-					uberTarget[client]=-1;
+					uberTarget[client] = -1;
 				}
 			}
 			else
 			{
 				return Plugin_Stop;
 			}
+		}
+		else if(charge <= 0.05)
+		{
+			return Plugin_Stop;
 		}
 	}
 	else

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,11 +78,11 @@ last time or to encourage others to do the same.
 */
 #define FORK_MAJOR_REVISION "1"
 #define FORK_MINOR_REVISION "18"
-#define FORK_STABLE_REVISION "1"
+#define FORK_STABLE_REVISION "2"
 #define FORK_SUB_REVISION "Unofficial"
-//#define FORK_DEV_REVISION "Build"
+#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."050"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."000"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -342,8 +342,8 @@ int allowedDetonations;
 float GoombaDamage = 0.05;
 float reboundPower = 300.0;
 bool canBossRTD;
-float SniperDamage = 2.5;
-float SniperMiniDamage = 2.1;
+float SniperDamage = 2.0;
+float SniperMiniDamage = 2.0;
 float BowDamage = 1.25;
 float BowDamageNon = 0.0;
 float BowDamageMini = 0.0;
@@ -585,7 +585,8 @@ static const char ff2versiontitles[][] =
 	"1.18.0",
 	"1.18.0",
 	"1.18.1",
-	"1.18.1"
+	"1.18.1",
+	"1.18.2"
 };
 
 static const char ff2versiondates[][] =
@@ -733,13 +734,18 @@ static const char ff2versiondates[][] =
 	"May 6, 2019",			//1.18.0
 	"May 6, 2019",			//1.18.0
 	"May 21, 2019",			//1.18.1
-	"May 21, 2019"			//1.18.1
+	"May 21, 2019",			//1.18.1
+	"May 31, 2019"			//1.18.2
 };
 
 stock void FindVersionData(Handle panel, int versionIndex)
 {
 	switch(versionIndex)
 	{
+		case 144:  //1.18.2
+		{
+			DrawPanelText(panel, "1) [Gameplay] Fixed Health HUD values being higher for most players (Batfoxkid)");
+		}
 		case 143:  //1.18.1
 		{
 			DrawPanelText(panel, "1) [Gameplay] Deadringers kills don't count towards StatTrak kills (Batfoxkid)");
@@ -1918,9 +1924,9 @@ public void OnPluginStart()
 	cvarPointType = CreateConVar("ff2_point_type", "0", "0-Use ff2_point_alive, 1-Use ff2_point_time, 2-Use both", _, true, 0.0, true, 2.0);
 	cvarPointDelay = CreateConVar("ff2_point_delay", "6", "Seconds to add to ff2_point_time per player");
 	cvarPointTime = CreateConVar("ff2_point_time", "45", "Time before unlocking the control point");
-	cvarAliveToEnable = CreateConVar("ff2_point_alive", "5", "The control point will only activate when there are this many people or less left alive", _, true, 0.0, true, 34.0);
+	cvarAliveToEnable = CreateConVar("ff2_point_alive", "5", "The control point will only activate when there are this many people or less left alive, allows setting a percentage", _, true, 0.0, true, 34.0);
 	cvarAnnounce = CreateConVar("ff2_announce", "120", "Amount of seconds to wait until FF2 info is displayed again.  0 to disable", _, true, 0.0);
-	cvarEnabled = CreateConVar("ff2_enabled", "1", "0-Disable FF2 (WHY?), 1-Enable FF2", FCVAR_DONTRECORD, true, 0.0, true, 1.0);
+	cvarEnabled = CreateConVar("ff2_enabled", "1", "0-Force Disable, 1-Standby, 2-Force Enable", FCVAR_DONTRECORD, true, 0.0, true, 2.0);
 	cvarCrits = CreateConVar("ff2_crits", "0", "Can the boss get random crits?", _, true, 0.0, true, 1.0);
 	cvarArenaRounds = CreateConVar("ff2_arena_rounds", "1", "Number of rounds to make arena before switching to FF2 (helps for slow-loading players)", _, true, 0.0);
 	cvarCircuitStun = CreateConVar("ff2_circuit_stun", "0", "Amount of seconds the Short Circuit stuns the boss for.  0 to disable", _, true, 0.0);
@@ -1931,7 +1937,7 @@ public void OnPluginStart()
 	cvarSpecForceBoss = CreateConVar("ff2_spec_force_boss", "0", "0-Spectators are excluded from the queue system, 1-Spectators are counted in the queue system", _, true, 0.0, true, 1.0);
 	cvarEnableEurekaEffect = CreateConVar("ff2_enable_eureka", "0", "0-Disable the Eureka Effect, 1-Enable the Eureka Effect", _, true, 0.0, true, 1.0);
 	cvarForceBossTeam = CreateConVar("ff2_force_team", "0", "0-Boss is always on Blu, 1-Boss is on a random team each round, 2-Boss is always on Red", _, true, 0.0, true, 3.0);
-	cvarHealthBar = CreateConVar("ff2_health_bar", "0", "0-Disable the health bar, 1-Show the health bar without lives, 2-Show the health bar with lives", _, true, 0.0, true, 2.0);
+	cvarHealthBar = CreateConVar("ff2_health_bar", "1", "0-Disable the health bar, 1-Show the health bar without lives, 2-Show the health bar with lives", _, true, 0.0, true, 2.0);
 	cvarLastPlayerGlow = CreateConVar("ff2_last_player_glow", "1", "How many players left before outlining everyone", _, true, 0.0, true, 34.0);
 	cvarBossTeleporter = CreateConVar("ff2_boss_teleporter", "0", "-1 to disallow all bosses from using teleporters, 0 to use TF2 logic, 1 to allow all bosses", _, true, -1.0, true, 1.0);
 	cvarBossSuicide = CreateConVar("ff2_boss_suicide", "0", "Allow the boss to suicide after the round starts?", _, true, 0.0, true, 1.0);
@@ -1945,8 +1951,8 @@ public void OnPluginStart()
 	cvarDebug = CreateConVar("ff2_debug", "0", "0-Disable FF2 debug output, 1-Enable debugging (not recommended)", _, true, 0.0, true, 1.0);
 	cvarDmg2KStreak = CreateConVar("ff2_dmg_kstreak", "250", "Minimum damage to increase killstreak count", _, true, 0.0);
 	cvarAirStrike = CreateConVar("ff2_dmg_airstrike", "250", "Minimum damage to increase head count for the Air-Strike", _, true, 0.0);
-	cvarSniperDamage = CreateConVar("ff2_sniper_dmg", "2.5", "Sniper Rifle normal multiplier", _, true, 0.0);
-	cvarSniperMiniDamage = CreateConVar("ff2_sniper_dmg_mini", "2.1", "Sniper Rifle mini-crit multiplier", _, true, 0.0);
+	cvarSniperDamage = CreateConVar("ff2_sniper_dmg", "2.0", "Sniper Rifle normal multiplier", _, true, 0.0);
+	cvarSniperMiniDamage = CreateConVar("ff2_sniper_dmg_mini", "2.0", "Sniper Rifle mini-crit multiplier", _, true, 0.0);
 	cvarBowDamage = CreateConVar("ff2_bow_dmg", "1.25", "Huntsman critical multiplier", _, true, 0.0);
 	cvarBowDamageNon = CreateConVar("ff2_bow_dmg_non", "0.0", "If not zero Huntsman has no crit boost, Huntsman normal non-crit multiplier", _, true, 0.0);
 	cvarBowDamageMini = CreateConVar("ff2_bow_dmg_mini", "0.0", "If not zero Huntsman is mini-crit boosted, Huntsman normal mini-crit multiplier", _, true, 0.0);
@@ -1959,7 +1965,7 @@ public void OnPluginStart()
 	cvarSelfKnockback = CreateConVar("ff2_selfknockback", "0", "Can the boss rocket jump but take fall damage too? 0 to disallow boss, 1 to allow boss", _, true, 0.0, true, 1.0);
 	cvarFF2TogglePrefDelay = CreateConVar("ff2_boss_toggle_delay", "45.0", "Delay between joining the server and asking the player for their preference, if it is not set.");
 	cvarNameChange = CreateConVar("ff2_name_change", "0", "0-Disable, 1-Add the current boss to the server name", _, true, 0.0, true, 1.0);
-	cvarKeepBoss = CreateConVar("ff2_boss_keep", "0", "-1-Players can't choose the same boss twice, 0-Nothing, 1-Players keep their current boss selection", _, true, -1.0, true, 1.0);
+	cvarKeepBoss = CreateConVar("ff2_boss_keep", "1", "-1-Players can't choose the same boss twice, 0-Nothing, 1-Players keep their current boss selection", _, true, -1.0, true, 1.0);
 	cvarSelectBoss = CreateConVar("ff2_boss_select", "1", "0-Disable, 1-Players can select bosses", _, true, 0.0, true, 1.0);
 	cvarToggleBoss = CreateConVar("ff2_boss_toggle", "1", "0-Disable, 1-Players can toggle being the boss", _, true, 0.0, true, 1.0);
 	cvarDuoBoss = CreateConVar("ff2_boss_companion", "1", "0-Disable, 1-Players can toggle being a companion", _, true, 0.0, true, 1.0);
@@ -1972,10 +1978,10 @@ public void OnPluginStart()
 	cvarDuoRandom = CreateConVar("ff2_companion_random", "0", "0-Next player in queue, 1-Random player is the companion", _, true, 0.0, true, 1.0);
 	cvarDuoMin = CreateConVar("ff2_companion_min", "4", "Minimum players required to enable duos", _, true, 1.0, true, 34.0);
 	cvarDuoRestore = CreateConVar("ff2_companion_restore", "0", "0-Disable, 1-Companions don't lose queue points", _, true, 0.0, true, 1.0);
-	cvarLowStab = CreateConVar("ff2_low_stab", "0", "0-Disable, 1-Low-player count stabs, market, and caber do more damage", _, true, 0.0, true, 1.0);
+	cvarLowStab = CreateConVar("ff2_low_stab", "1", "0-Disable, 1-Low-player count stabs, market, and caber do more damage", _, true, 0.0, true, 1.0);
 	cvarGameText = CreateConVar("ff2_text_game", "0", "For game messages: 0-Use HUD texts, 1-Use game_text_tf entities, 2-Include boss intro and timer too", _, true, 0.0, true, 2.0);
 	cvarAnnotations = CreateConVar("ff2_text_msg", "0", "For backstabs and such: 0-Use hint texts, 1-Use annotations, 2-Use game_text_tf entities", _, true, 0.0, true, 2.0);
-	cvarTellName = CreateConVar("ff2_text_names", "0", "For backstabs and such: 0-Don't show player/boss names, 1-Show player/boss names", _, true, 0.0, true, 1.0);
+	cvarTellName = CreateConVar("ff2_text_names", "1", "For backstabs and such: 0-Don't show player/boss names, 1-Show player/boss names", _, true, 0.0, true, 1.0);
 	cvarShieldType = CreateConVar("ff2_shield_type", "1", "0-None, 1-Breaks on any hit, 2-Breaks if it'll kill, 3-Breaks if shield HP is depleted or melee hit, 4-Breaks if shield or player HP is depleted", _, true, 0.0, true, 4.0);
 	cvarShieldHealth = CreateConVar("ff2_shield_health", "500", "Maximum amount of health a Shield has if ff2_shield_type is 3 or 4", _, true, 0.0);
 	cvarShieldResist = CreateConVar("ff2_shield_resistance", "0.75", "Maximum amount (inverted) precentage of damage resistance a Shield has if ff2_shield_type is 3 or 4", _, true, 0.0, true, 1.0);
@@ -2754,7 +2760,11 @@ public void OnConfigsExecuted()
 	GetConVarString(FindConVar("mp_humans_must_join_team"), mp_humans_must_join_team, sizeof(mp_humans_must_join_team));
 	GetConVarString(hostName=FindConVar("hostname"), oldName, sizeof(oldName));
 
-	if(IsFF2Map() && GetConVarBool(cvarEnabled))
+	if(GetConVarInt(cvarEnabled)>1)
+	{
+		EnableFF2();
+	}
+	else if(IsFF2Map() && GetConVarInt(cvarEnabled)>0)
 	{
 		EnableFF2();
 	}
@@ -2832,7 +2842,7 @@ public void EnableFF2()
 	SniperClimbDelay = GetConVarFloat(cvarSniperClimbDelay);
 	QualityWep = GetConVarInt(cvarQualityWep);
 	canBossRTD = GetConVarBool(cvarBossRTD);
-	AliveToEnable = GetConVarInt(cvarAliveToEnable);
+	AliveToEnable = GetConVarFloat(cvarAliveToEnable);
 	PointsInterval = GetConVarInt(cvarPointsInterval);
 	PointsInterval2 = GetConVarFloat(cvarPointsInterval);
 	PointsDamage = GetConVarInt(cvarPointsDamage);
@@ -3503,7 +3513,22 @@ public void CvarChange(Handle convar, const char[] oldValue, const char[] newVal
 	}
 	else if(convar==cvarEnabled)
 	{
-		StringToInt(newValue) ? (changeGamemode=Enabled ? 0 : 1) : (changeGamemode=!Enabled ? 0 : 2);
+		switch(StringToInt(newValue))
+		{
+			case 0:
+			{
+				changeGamemode = Enabled ? 2 : 0;
+			}
+			case 1:
+			{
+				if(IsFF2Map() && !Enabled)
+					changeGamemode = 1;
+			}
+			case 2:
+			{
+				changeGamemode = Enabled ? 0 : 1;
+			}
+		}
 	}
 }
 
@@ -3529,7 +3554,7 @@ public Action SMAC_OnCheatDetected(int client, const char[] module, DetectionTyp
 
 public Action Timer_Announce(Handle timer)
 {
-	static int announcecount=-1;
+	static int announcecount = -1;
 	announcecount++;
 	if(Announce>1.0 && Enabled2)
 	{
@@ -3555,7 +3580,7 @@ public Action Timer_Announce(Handle timer)
 				}
 				else					// Guess not, play the 4th thing and next is 5
 				{
-					announcecount=5;
+					announcecount = 5;
 					FPrintToChatAll("%t", "DevAd", PLUGIN_VERSION);
 				}
 			}
@@ -3571,13 +3596,13 @@ public Action Timer_Announce(Handle timer)
 				}
 				else					// Guess not either, play the last thing and next is 0
 				{
-					announcecount=0;
+					announcecount = 0;
 					FPrintToChatAll("%t", "type_ff2_to_open_menu");
 				}
 			}
 			default:
 			{
-				announcecount=0;
+				announcecount = 0;
 				FPrintToChatAll("%t", "type_ff2_to_open_menu");
 			}
 		}
@@ -3609,7 +3634,7 @@ stock bool IsFF2Map()
 	}
 
 	Handle file=OpenFile(config, "r");
-	if(file==INVALID_HANDLE)
+	if(file == INVALID_HANDLE)
 	{
 		LogToFile(eLog, "[!!!] Error reading maps from %s, disabling plugin.", config);
 		return false;
@@ -3619,7 +3644,7 @@ stock bool IsFF2Map()
 	while(ReadFileLine(file, config, sizeof(config)) && tries<100)
 	{
 		tries++;
-		if(tries==100)
+		if(tries == 100)
 		{
 			LogToFile(eLog, "[!!!] Breaking infinite loop when trying to check the map.");
 			return false;
@@ -6634,13 +6659,13 @@ public Action Timer_MakeBoss(Handle timer, any boss)
 		PointTime=GetConVarInt(cvarPointTime);
 	}
 
-	if(KvGetNum(BossKV[Special[boss]], "pointalive", -1)>=0)	// Can't be below 0, it's players
+	if(KvGetNum(BossKV[Special[boss]], "pointalive", -1)>=0)	// Can't be below 0, it's players/ratio
 	{
-		AliveToEnable=KvGetNum(BossKV[Special[boss]], "pointalive", -1);
+		AliveToEnable=KvGetFloat(BossKV[Special[boss]], "pointalive", -1);
 	}
 	else
 	{
-		AliveToEnable=GetConVarInt(cvarAliveToEnable);
+		AliveToEnable=GetConVarFloat(cvarAliveToEnable);
 	}
 
 	if(KvGetNum(BossKV[Special[boss]], "countdownhealth", -1)>=0)	// Also can't be below 0, it's health
@@ -9330,9 +9355,9 @@ public Action ClientTimer(Handle timer)
 				{
 					if(weapon==GetPlayerWeaponSlot(client, TFWeaponSlot_Primary) && !IsValidEntity(GetPlayerWeaponSlot(client, TFWeaponSlot_Secondary)) && shieldCrits)  //Demoshields
 					{
-						addthecrit=true;
-						if(shieldCrits==1)
-							cond=TFCond_CritCola;
+						addthecrit = true;
+						if(shieldCrits == 1)
+							cond = TFCond_CritCola;
 					}
 				}
 				case TFClass_Spy:
@@ -9353,7 +9378,7 @@ public Action ClientTimer(Handle timer)
 				{
 					if(weapon==GetPlayerWeaponSlot(client, TFWeaponSlot_Primary) && StrEqual(classname, "tf_weapon_sentry_revenge", false))
 					{
-						int sentry=FindSentry(client);
+						int sentry = FindSentry(client);
 						if(IsValidEntity(sentry) && IsBoss(GetEntPropEnt(sentry, Prop_Send, "m_hEnemy")))
 						{
 							SetEntProp(client, Prop_Send, "m_iRevengeCrits", 3);
@@ -9387,10 +9412,10 @@ public Action ClientTimer(Handle timer)
 
 stock int FindSentry(int client)
 {
-	int entity=-1;
-	while((entity=FindEntityByClassname2(entity, "obj_sentrygun"))!=-1)
+	int entity = -1;
+	while((entity=FindEntityByClassname2(entity, "obj_sentrygun")) != -1)
 	{
-		if(GetEntPropEnt(entity, Prop_Send, "m_hBuilder")==client)
+		if(GetEntPropEnt(entity, Prop_Send, "m_hBuilder") == client)
 			return entity;
 	}
 	return -1;
@@ -9401,12 +9426,12 @@ public Action BossTimer(Handle timer)
 	if(!Enabled || CheckRoundState()==2)
 		return Plugin_Stop;
 
-	bool validBoss=false;
+	bool validBoss = false;
 	int StatHud = GetConVarInt(cvarStatHud);
 	int HealHud = GetConVarInt(cvarHealingHud);
 	for(int boss; boss<=MaxClients; boss++)
 	{
-		int client=Boss[boss];
+		int client = Boss[boss];
 		if(!IsValidClient(client) || !(FF2flags[client] & FF2FLAG_USEBOSSTIMER))
 			continue;
 
@@ -9474,9 +9499,9 @@ public Action BossTimer(Handle timer)
 			continue;
 		}
 
-		validBoss=true;
+		validBoss = true;
 
-		if(BossSpeed[Special[boss]]>0)	// Above 0, uses the classic FF2 method
+		if(BossSpeed[Special[boss]] > 0)	// Above 0, uses the classic FF2 method
 		{
 			SetEntPropFloat(client, Prop_Data, "m_flMaxspeed", BossSpeed[Special[boss]]+0.7*(100-BossHealth[boss]*100/BossLivesMax[boss]/BossHealthMax[boss]));
 		}
@@ -9486,10 +9511,10 @@ public Action BossTimer(Handle timer)
 		}
 		// Below 0, TF2's default speeds and whatever attributes or conditions
 
-		//if(BossHealth[boss]<=0 && IsPlayerAlive(client))  //Wat.  TODO:  Investigate
-			//BossHealth[boss]=1;
+		//if(BossHealth[boss] <= 0 && IsPlayerAlive(client))  //Wat.  TODO:  Investigate
+			//BossHealth[boss] = 1;
 
-		if(BossLivesMax[boss]>1)
+		if(BossLivesMax[boss] > 1)
 		{
 			SetHudTextParams(-1.0, 0.77, 0.15, 255, 255, 255, 255);
 			FF2_ShowSyncHudText(client, livesHUD, "%t", "Boss Lives Left", BossLives[boss], BossLivesMax[boss]);
@@ -9525,12 +9550,12 @@ public Action BossTimer(Handle timer)
 							EmitSoundToClient(target, sound, client, _, _, _, _, _, client, position);
 						}
 					}
-					FF2flags[client]&=~FF2FLAG_TALKING;
+					FF2flags[client] &= ~FF2FLAG_TALKING;
 					emitRageSound[boss]=false;
 				}
 			}
 		}
-		else if(BossRageDamage[0]<99999)	// ragedamage below 999999
+		else if(BossRageDamage[0] < 99999)	// ragedamage below 999999
 		{
 			SetHudTextParams(-1.0, 0.83, 0.15, 255, 255, 255, 255);
 			FF2_ShowSyncHudText(client, rageHUD, "%t", "rage_meter", RoundFloat(BossCharge[boss][0]));
@@ -9554,9 +9579,9 @@ public Action BossTimer(Handle timer)
 			{
 				char plugin_name[64];
 				KvGetString(BossKV[Special[boss]], "plugin_name", plugin_name, sizeof(plugin_name));
-				int slot=KvGetNum(BossKV[Special[boss]], "arg0", 0);
-				int buttonmode=KvGetNum(BossKV[Special[boss]], "buttonmode", 0);
-				if(slot<1)
+				int slot = KvGetNum(BossKV[Special[boss]], "arg0", 0);
+				int buttonmode = KvGetNum(BossKV[Special[boss]], "buttonmode", 0);
+				if(slot < 1)
 					continue;
 
 				KvGetString(BossKV[Special[boss]], "life", ability, sizeof(ability), "");
@@ -9571,7 +9596,7 @@ public Action BossTimer(Handle timer)
 					int count=ExplodeString(ability, " ", lives, MAXRANDOMS, 3);
 					for(int n; n<count; n++)
 					{
-						if(StringToInt(lives[n])==BossLives[boss])
+						if(StringToInt(lives[n]) == BossLives[boss])
 						{
 							char ability_name[64];
 							KvGetString(BossKV[Special[boss]], "name", ability_name, sizeof(ability_name));
@@ -9587,7 +9612,7 @@ public Action BossTimer(Handle timer)
 			}
 		}
 
-		if(RedAlivePlayers<=lastPlayerGlow)
+		if(RedAlivePlayers <= lastPlayerGlow)
 			SetClientGlow(client, 0.5, 3.0);
 
 		if(RedAlivePlayers==1 && !executed2 && GetConVarInt(cvarHealthHud)<2)
@@ -9597,11 +9622,11 @@ public Action BossTimer(Handle timer)
 			{
 				if(IsBoss(target))
 				{
-					int boss2=GetBossIndex(target);
+					int boss2 = GetBossIndex(target);
 					KvRewind(BossKV[Special[boss2]]);
 					KvGetString(BossKV[Special[boss2]], "name", name, sizeof(name), "=Failed name=");
 					char bossLives[10];
-					if(BossLives[boss2]>1)
+					if(BossLives[boss2] > 1)
 					{
 						Format(bossLives, sizeof(bossLives), "x%i", BossLives[boss2]);
 					}
@@ -9636,21 +9661,21 @@ public Action BossTimer(Handle timer)
 			}
 		}
 
-		if(BossCharge[boss][0]<rageMax[client])
+		if(BossCharge[boss][0] < rageMax[client])
 		{
-			BossCharge[boss][0]+=OnlyScoutsLeft()*0.2;
-			if(BossCharge[boss][0]>rageMax[client])
-				BossCharge[boss][0]=rageMax[client];
+			BossCharge[boss][0] += OnlyScoutsLeft()*0.2;
+			if(BossCharge[boss][0] > rageMax[client])
+				BossCharge[boss][0] = rageMax[client];
 		}
 
-		HPTime-=0.2;
-		if(HPTime<0)
-			HPTime=0.0;
+		HPTime -= 0.2;
+		if(HPTime < 0)
+			HPTime = 0.0;
 
 		for(int client2; client2<=MaxClients; client2++)
 		{
-			if(KSpreeTimer[client2]>0)
-				KSpreeTimer[client2]-=0.2;
+			if(KSpreeTimer[client2] > 0)
+				KSpreeTimer[client2] -= 0.2;
 		}
 	}
 
@@ -9756,13 +9781,13 @@ public Action Timer_RPS(Handle timer, int client)
 
 	RPSLosses[client]++;
 
-	if(RPSLosses[client]<0)
-		RPSLosses[client]=0;
+	if(RPSLosses[client] < 0)
+		RPSLosses[client] = 0;
 
-	if(RPSHealth[client]==-1)
+	if(RPSHealth[client] == -1)
 		RPSHealth[client]=BossHealth[boss];
 
-	if(RPSLosses[client]>=GetConVarInt(cvarRPSLimit))
+	if(RPSLosses[client] >= GetConVarInt(cvarRPSLimit))
 	{
 		if(IsValidClient(RPSWinner) && FF2_GetBossHealth(boss)>1349)
 		{
@@ -9773,7 +9798,7 @@ public Action Timer_RPS(Handle timer, int client)
 			ForcePlayerSuicide(client);
 		}
 	}
-	else if(FF2_GetBossHealth(boss)>(1349*GetConVarInt(cvarRPSLimit)) && GetConVarBool(cvarRPSDivide))
+	else if(FF2_GetBossHealth(boss) > (1349*GetConVarInt(cvarRPSLimit)) && GetConVarBool(cvarRPSDivide))
 	{
 		if(IsValidClient(RPSWinner))
 			SDKHooks_TakeDamage(client, RPSWinner, RPSWinner, float((RPSHealth[client]/GetConVarInt(cvarRPSLimit))-999)/1.35, DMG_GENERIC, -1);
@@ -10316,8 +10341,8 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 	if(CheckRoundState() == 2)
 		return Plugin_Continue;
 
-	RedAlivePlayers=0;
-	BlueAlivePlayers=0;
+	RedAlivePlayers = 0;
+	BlueAlivePlayers = 0;
 	for(int client=1; client<=MaxClients; client++)
 	{
 		if(IsClientInGame(client) && IsPlayerAlive(client))
@@ -10341,8 +10366,10 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 	if(!RedAlivePlayers)
 	{
 		ForceTeamWin(BossTeam);
+		return Plugin_Continue;
 	}
-	else if(RedAlivePlayers==1 && BlueAlivePlayers && Boss[0] && !DrawGameTimer && LastMan)
+
+	if(RedAlivePlayers==1 && BlueAlivePlayers && Boss[0] && !DrawGameTimer && LastMan)
 	{
 		char sound[PLATFORM_MAX_PATH];
 		if(RandomSound("sound_lastman", sound, sizeof(sound)))
@@ -10352,8 +10379,30 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 		}
 		LastMan=false;
 	}
-	else if(PointType!=1 && RedAlivePlayers<=AliveToEnable && !executed)
+
+	if(RedAlivePlayers<=countdownPlayers && BossHealth[0]>countdownHealth && countdownTime>1 && !executed2)
 	{
+		if(FindEntityByClassname2(-1, "team_control_point") != -1)
+		{
+			timeleft = countdownTime;
+			DrawGameTimer = CreateTimer(1.0, Timer_DrawGame, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+		}
+		executed2 = true;
+	}
+
+	if(PointType!=1 && AliveToEnable>0 && !executed)
+	{
+		if(AliveToEnable < 1)
+		{
+			if((RedAlivePlayers/playing) > AliveToEnable)
+				return Plugin_Continue;	
+		}
+		else
+		{
+			if(RedAlivePlayers > AliveToEnable)
+				return Plugin_Continue;	
+		}
+
 		for(int client=1; client<=MaxClients; client++)
 		{
 			if(IsClientInGame(client) && IsPlayerAlive(client))
@@ -10368,7 +10417,7 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 				}
 			}
 		}
-		if(RedAlivePlayers==AliveToEnable)
+		if(RedAlivePlayers == AliveToEnable)
 		{
 			char sound[64];
 			if(GetRandomInt(0, 2))
@@ -10383,17 +10432,7 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 		}
 		SetArenaCapEnableTime(0.0);
 		SetControlPoint(true);
-		executed=true;
-	}
-
-	if(RedAlivePlayers<=countdownPlayers && BossHealth[0]>countdownHealth && countdownTime>1 && !executed2)
-	{
-		if(FindEntityByClassname2(-1, "team_control_point")!=-1)
-		{
-			timeleft=countdownTime;
-			DrawGameTimer=CreateTimer(1.0, Timer_DrawGame, _, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
-		}
-		executed2=true;
+		executed = true;
 	}
 	return Plugin_Continue;
 }
@@ -10430,23 +10469,26 @@ public Action Timer_DrawGame(Handle timer)
 	SetHudTextParams(-1.0, 0.17, 1.1, 255, 255, 255, 255);
 
 	char message[512], name[64];
-	for(int client; client<=MaxClients; client++)
+	if(!Companions && GetConVarInt(cvarGameText)>0 && RedAlivePlayers==1 && GetConVarInt(cvarHealthHud)<2)
 	{
-		if(IsBoss(client))
+		for(int client; client<=MaxClients; client++)
 		{
-			int boss2=GetBossIndex(client);
-			KvRewind(BossKV[Special[boss2]]);
-			KvGetString(BossKV[Special[boss2]], "name", name, sizeof(name), "=Failed name=");
-			char bossLives[10];
-			if(BossLives[boss2]>1)
+			if(IsBoss(client))
 			{
-				Format(bossLives, sizeof(bossLives), "x%i", BossLives[boss2]);
+				int boss2 = GetBossIndex(client);
+				KvRewind(BossKV[Special[boss2]]);
+				KvGetString(BossKV[Special[boss2]], "name", name, sizeof(name), "=Failed name=");
+				char bossLives[10];
+				if(BossLives[boss2] > 1)
+				{
+					Format(bossLives, sizeof(bossLives), "x%i", BossLives[boss2]);
+				}
+				else
+				{
+					Format(bossLives, sizeof(bossLives), "");
+				}
+				Format(message, sizeof(message), "%s\n%t", message, "ff2_hp", name, BossHealth[boss2]-BossHealthMax[boss2]*(BossLives[boss2]-1), BossHealthMax[boss2], bossLives);
 			}
-			else
-			{
-				Format(bossLives, sizeof(bossLives), "");
-			}
-			Format(message, sizeof(message), "%s\n%t", message, "ff2_hp", name, BossHealth[boss2]-BossHealthMax[boss2]*(BossLives[boss2]-1), BossHealthMax[boss2], bossLives);
 		}
 	}
 	for(int client; client<=MaxClients; client++)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."001"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."002"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -6640,9 +6640,9 @@ public Action Timer_MakeBoss(Handle timer, any boss)
 		PointTime = GetConVarInt(cvarPointTime);
 	}
 
-	if(KvGetNum(BossKV[Special[boss]], "pointalive", -1) >= 0)	// Can't be below 0, it's players/ratio
+	if(KvGetFloat(BossKV[Special[boss]], "pointalive", -1.0) >= 0)	// Can't be below 0, it's players/ratio
 	{
-		AliveToEnable = KvGetFloat(BossKV[Special[boss]], "pointalive", -1);
+		AliveToEnable = KvGetFloat(BossKV[Special[boss]], "pointalive", -1.0);
 	}
 	else
 	{
@@ -6658,9 +6658,9 @@ public Action Timer_MakeBoss(Handle timer, any boss)
 		countdownHealth = GetConVarInt(cvarCountdownHealth);
 	}
 
-	if(KvGetNum(BossKV[Special[boss]], "countdownalive", -1) >= 0)	// Yet again, can't be below 0
+	if(KvGetFloat(BossKV[Special[boss]], "countdownalive", -1.0) >= 0)	// Yet again, can't be below 0
 	{
-		countdownPlayers = KvGetFloat(BossKV[Special[boss]], "countdownalive", -1);
+		countdownPlayers = KvGetFloat(BossKV[Special[boss]], "countdownalive", -1.0);
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."048"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."049"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -1996,7 +1996,7 @@ public void OnPluginStart()
 	cvarStatHud = CreateConVar("ff2_hud_stats", "-1", "-1-Disable, 0-Only by ff2_stats_bosses override, 1-Show only to client, 2-Show to anybody", _, true, -1.0, true, 2.0);
 	cvarStatPlayers = CreateConVar("ff2_stats_players", "6", "0-Disable, #-Players required to use StatTrak", _, true, 0.0, true, 34.0);
 	cvarStatWin2Lose = CreateConVar("ff2_stats_chat", "-1", "-1-Disable, 0-Only by ff2_stats_bosses override, 1-Show only to client if changed, 2-Show to everybody if changed, 3-Show only to client, 4-Show to everybody", _, true, -1.0, true, 4.0);
-	cvarHealthHud = CreateConVar("ff2_hud_health", "0", "0-Disable, 1-Show boss's lives left, 2-Show boss's total health", _, true, 0.0, true, 2.0);
+	cvarHealthHud = CreateConVar("ff2_hud_health", "0", "0-Disable, 1-Show boss's lives left, 2-Show boss's total health", _, true, 0.0, true, 4.0);
 
 	//The following are used in various subplugins
 	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
@@ -8103,7 +8103,7 @@ public Action Command_GetHPCmd(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(CheckRoundState()!=1 || GetConVarInt(cvarHealthHud)>1)
+	if(CheckRoundState()!=1 || GetConVarInt(cvarHealthHud)==2 || GetConVarInt(cvarHealthHud)>3)
 		return Plugin_Continue;
 
 	Command_GetHP(client);
@@ -9590,7 +9590,7 @@ public Action BossTimer(Handle timer)
 		if(RedAlivePlayers<=lastPlayerGlow)
 			SetClientGlow(client, 0.5, 3.0);
 
-		if(RedAlivePlayers==1 && !executed2 && GetConVarInt(cvarHealthHud)<2)
+		if(RedAlivePlayers==1 && !executed2 && GetConVarInt(cvarHealthHud)!=2 && GetConVarInt(cvarHealthHud)<4)
 		{
 			char message[512], name[64];
 			for(int target; target<=MaxClients; target++)  //TODO: Why is this for loop needed when we're already in a boss for loop
@@ -9667,7 +9667,7 @@ public Action GlobalTimer(Handle timer)
 	if(!Enabled || CheckRoundState()==2 || CheckRoundState()==-1 || HealthHud<1)
 		return Plugin_Stop;
 
-	if(CheckRoundState() == 0)
+	if(CheckRoundState()==0 || (HealthHud>2 && Companions))
 		return Plugin_Continue;
 
 	//int HealthBar = GetConVarInt(cvarHealthBar);
@@ -9699,39 +9699,43 @@ public Action GlobalTimer(Handle timer)
 				}
 			}
 
-			if(HealthHud < 2)	// I have no idea for companions with lives
+			if(HealthHud > 3)
 			{
 				for(int clients=1; clients<=MaxClients; clients++)
 				{
 					if(IsBoss(clients))
 					{
 						boss = GetBossIndex(clients);
-						current += BossLives[boss];
-						max += BossLivesMax[boss];
-						bosses++;
+						current = BossHealth[boss]-BossHealthMax[boss]*(BossLives[boss]-1);
+						max = BossHealthMax[boss];
+						lives = BossLives[boss];
 					}
 				}
 
-				if(current > bosses)
+				if(lives > 1)
 				{
-					FF2_ShowSyncHudText(client, healthHUD, "%t", "Boss Lives Left", current, max);
+					FF2_ShowSyncHudText(client, healthHUD, "%i / %ix%i", current, max, lives);
+				}
+				else
+				{
+					FF2_ShowSyncHudText(client, healthHUD, "%i / %i", current, max);
 				}
 			}
-			/*else if(HealthBar > 1)	// Decided against it, even as a ConVar
+			else if(HealthHud > 2)
 			{
 				for(int clients=1; clients<=MaxClients; clients++)
 				{
 					if(IsBoss(clients))
 					{
 						boss = GetBossIndex(clients);
-						current += BossHealth[boss];
-						max += BossHealthMax[boss]*BossLivesMax[boss];
+						current = BossLives[boss];
+						max = BossLivesMax[boss];
+						break;
 					}
 				}
-
-				FF2_ShowSyncHudText(client, healthHUD, "%i / %i", current, max);
-			}*/
-			else
+				FF2_ShowSyncHudText(client, healthHUD, "%t", "Boss Lives Left", current, max);
+			}
+			else if(HealthHud > 1)
 			{
 				for(int clients=1; clients<=MaxClients; clients++)
 				{
@@ -9752,6 +9756,24 @@ public Action GlobalTimer(Handle timer)
 				else
 				{
 					FF2_ShowSyncHudText(client, healthHUD, "%i / %i", current, max);
+				}
+			}
+			else
+			{
+				for(int clients=1; clients<=MaxClients; clients++)
+				{
+					if(IsBoss(clients))
+					{
+						boss = GetBossIndex(clients);
+						current += BossLives[boss];
+						max += BossLivesMax[boss];
+						bosses++;
+					}
+				}
+
+				if(current > bosses)
+				{
+					FF2_ShowSyncHudText(client, healthHUD, "%t", "Boss Lives Left", current, max);
 				}
 			}
 		}
@@ -10270,9 +10292,9 @@ public Action OnPlayerDeath(Handle event, const char[] eventName, bool dontBroad
 
 public Action Timer_Damage(Handle timer, any userid)
 {
-	int client=GetClientOfUserId(userid);
+	int client = GetClientOfUserId(userid);
 	if(IsValidClient(client, false))
-		FPrintToChat(client, "{olive}%t. %t{default}", "damage", Damage[client], "scores", RoundFloat(Damage[client]/PointsInterval2));
+		FPrintToChat(client, "{olive}%t. %t{default}", "damage", Damage[client], "scores", RoundToFloor(Damage[client]/PointsInterval2));
 
 	return Plugin_Continue;
 }
@@ -11295,11 +11317,15 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 							EmitSoundToClient(attacker, "ambient/lightsoff.wav", _, _, _, _, 0.6, _, _, position, _, false);
 							EmitSoundToClient(client, "ambient/lightson.wav", _, _, _, _, 0.6, _, _, position, _, false);
 
-							char sound[PLATFORM_MAX_PATH];
-							if(RandomSound("sound_cabered", sound, sizeof(sound)))
+							
+							if(BossHealth[boss]-BossHealthMax[boss]*(BossLives[boss]-1) > damage*3)
 							{
-								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
-								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+								char sound[PLATFORM_MAX_PATH];
+								if(RandomSound("sound_cabered", sound, sizeof(sound)))
+								{
+									EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+									EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+								}
 							}
 
 							if(allowedDetonations < 3)
@@ -11481,11 +11507,14 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 							EmitSoundToClient(attacker, "player/doubledonk.wav", _, _, _, _, 0.6, _, _, position, _, false);
 							EmitSoundToClient(client, "player/doubledonk.wav", _, _, _, _, 0.6, _, _, position, _, false);
 
-							char sound[PLATFORM_MAX_PATH];
-							if(RandomSound("sound_marketed", sound, sizeof(sound)))
+							if(BossHealth[boss]-BossHealthMax[boss]*(BossLives[boss]-1) > damage*3)
 							{
-								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
-								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+								char sound[PLATFORM_MAX_PATH];
+								if(RandomSound("sound_marketed", sound, sizeof(sound)))
+								{
+									EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+									EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, _, _, _, false);
+								}
 							}
 
 							HealthBarMode = true;
@@ -11666,11 +11695,15 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 							}
 						}
 
-						char sound[PLATFORM_MAX_PATH];
-						if(RandomSound("sound_stabbed", sound, sizeof(sound), boss))
+						
+						if(BossHealth[boss]-BossHealthMax[boss]*(BossLives[boss]-1) > damage*3)
 						{
-							EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, Boss[boss], _, _, false);
-							EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, Boss[boss], _, _, false);
+							char sound[PLATFORM_MAX_PATH];
+							if(RandomSound("sound_stabbed", sound, sizeof(sound), boss))
+							{
+								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, Boss[boss], _, _, false);
+								EmitSoundToAllExcept(SOUNDEXCEPT_VOICE, sound, _, _, _, _, _, _, Boss[boss], _, _, false);
+							}
 						}
 					}
 					switch(index)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -82,7 +82,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."049"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."050"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -1996,7 +1996,7 @@ public void OnPluginStart()
 	cvarStatHud = CreateConVar("ff2_hud_stats", "-1", "-1-Disable, 0-Only by ff2_stats_bosses override, 1-Show only to client, 2-Show to anybody", _, true, -1.0, true, 2.0);
 	cvarStatPlayers = CreateConVar("ff2_stats_players", "6", "0-Disable, #-Players required to use StatTrak", _, true, 0.0, true, 34.0);
 	cvarStatWin2Lose = CreateConVar("ff2_stats_chat", "-1", "-1-Disable, 0-Only by ff2_stats_bosses override, 1-Show only to client if changed, 2-Show to everybody if changed, 3-Show only to client, 4-Show to everybody", _, true, -1.0, true, 4.0);
-	cvarHealthHud = CreateConVar("ff2_hud_health", "0", "0-Disable, 1-Show boss's lives left, 2-Show boss's total health", _, true, 0.0, true, 4.0);
+	cvarHealthHud = CreateConVar("ff2_hud_health", "0", "0-Disable, 1-Show boss's lives left, 2-Show boss's total health", _, true, 0.0, true, 2.0);
 
 	//The following are used in various subplugins
 	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
@@ -8103,7 +8103,7 @@ public Action Command_GetHPCmd(int client, int args)
 		return Plugin_Handled;
 	}
 
-	if(CheckRoundState()!=1 || GetConVarInt(cvarHealthHud)==2 || GetConVarInt(cvarHealthHud)>3)
+	if(CheckRoundState()!=1 || GetConVarInt(cvarHealthHud)>1)
 		return Plugin_Continue;
 
 	Command_GetHP(client);
@@ -9590,7 +9590,7 @@ public Action BossTimer(Handle timer)
 		if(RedAlivePlayers<=lastPlayerGlow)
 			SetClientGlow(client, 0.5, 3.0);
 
-		if(RedAlivePlayers==1 && !executed2 && GetConVarInt(cvarHealthHud)!=2 && GetConVarInt(cvarHealthHud)<4)
+		if(RedAlivePlayers==1 && !executed2 && GetConVarInt(cvarHealthHud)<2)
 		{
 			char message[512], name[64];
 			for(int target; target<=MaxClients; target++)  //TODO: Why is this for loop needed when we're already in a boss for loop
@@ -9667,15 +9667,15 @@ public Action GlobalTimer(Handle timer)
 	if(!Enabled || CheckRoundState()==2 || CheckRoundState()==-1 || HealthHud<1)
 		return Plugin_Stop;
 
-	if(CheckRoundState()==0 || (HealthHud>2 && Companions))
+	if(CheckRoundState()==0)
 		return Plugin_Continue;
 
 	//int HealthBar = GetConVarInt(cvarHealthBar);
-	int current, max, bosses, lives, boss;
 	for(int client=1; client<=MaxClients; client++)
 	{
 		if(IsValidClient(client))
 		{
+			int current, max, bosses, lives, boss;
 			if(IsPlayerAlive(client))
 			{
 				if(HealthBarMode)
@@ -9699,43 +9699,7 @@ public Action GlobalTimer(Handle timer)
 				}
 			}
 
-			if(HealthHud > 3)
-			{
-				for(int clients=1; clients<=MaxClients; clients++)
-				{
-					if(IsBoss(clients))
-					{
-						boss = GetBossIndex(clients);
-						current = BossHealth[boss]-BossHealthMax[boss]*(BossLives[boss]-1);
-						max = BossHealthMax[boss];
-						lives = BossLives[boss];
-					}
-				}
-
-				if(lives > 1)
-				{
-					FF2_ShowSyncHudText(client, healthHUD, "%i / %ix%i", current, max, lives);
-				}
-				else
-				{
-					FF2_ShowSyncHudText(client, healthHUD, "%i / %i", current, max);
-				}
-			}
-			else if(HealthHud > 2)
-			{
-				for(int clients=1; clients<=MaxClients; clients++)
-				{
-					if(IsBoss(clients))
-					{
-						boss = GetBossIndex(clients);
-						current = BossLives[boss];
-						max = BossLivesMax[boss];
-						break;
-					}
-				}
-				FF2_ShowSyncHudText(client, healthHUD, "%t", "Boss Lives Left", current, max);
-			}
-			else if(HealthHud > 1)
+			if(HealthHud > 1)
 			{
 				for(int clients=1; clients<=MaxClients; clients++)
 				{

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -2,22 +2,23 @@
 #include <morecolors>
 #include <sdktools>
 
-#define FF2FLAG_UBERREADY				(1<<1)		//Used when medic says "I'm charged!"
-#define FF2FLAG_ISBUFFED				(1<<2)		//Used when soldier uses the Battalion's Backup
+#define FF2FLAG_UBERREADY			(1<<1)		//Used when medic says "I'm charged!"
+#define FF2FLAG_ISBUFFED			(1<<2)		//Used when soldier uses the Battalion's Backup
 #define FF2FLAG_CLASSTIMERDISABLED 		(1<<3)		//Used to prevent clients' timer
-#define FF2FLAG_HUDDISABLED				(1<<4)		//Used to prevent custom hud from clients' timer
-#define FF2FLAG_BOTRAGE					(1<<5)		//Used by bots to use Boss's rage
-#define FF2FLAG_TALKING					(1<<6)		//Used by Bosses with "sound_block_vo" to disable block for some lines
-#define FF2FLAG_ALLOWSPAWNINBOSSTEAM	(1<<7)		//Used to allow spawn players in Boss's team
+#define FF2FLAG_HUDDISABLED			(1<<4)		//Used to prevent custom hud from clients' timer
+#define FF2FLAG_BOTRAGE				(1<<5)		//Used by bots to use Boss's rage
+#define FF2FLAG_TALKING				(1<<6)		//Used by Bosses with "sound_block_vo" to disable block for some lines
+#define FF2FLAG_ALLOWSPAWNINBOSSTEAM		(1<<7)		//Used to allow spawn players in Boss's team
 #define FF2FLAG_USEBOSSTIMER			(1<<8)		//Used to prevent Boss's timer
 #define FF2FLAG_USINGABILITY			(1<<9)		//Used to prevent Boss's hints about abilities buttons
-#define FF2FLAG_CLASSHELPED				(1<<10)
-#define FF2FLAG_HASONGIVED				(1<<11)
-#define FF2FLAG_CHANGECVAR				(1<<12)		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)
-#define FF2FLAG_ALLOW_HEALTH_PICKUPS	(1<<13)		//Used to prevent bosses from picking up health
+#define FF2FLAG_CLASSHELPED			(1<<10)
+#define FF2FLAG_HASONGIVED			(1<<11)
+#define FF2FLAG_CHANGECVAR			(1<<12)		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)
+#define FF2FLAG_ALLOW_HEALTH_PICKUPS		(1<<13)		//Used to prevent bosses from picking up health
 #define FF2FLAG_ALLOW_AMMO_PICKUPS		(1<<14)		//Used to prevent bosses from picking up ammo
 #define FF2FLAG_ROCKET_JUMPING			(1<<15)		//Used when a soldier is rocket jumping
-#define FF2FLAGS_SPAWN					~FF2FLAG_UBERREADY & ~FF2FLAG_ISBUFFED & ~FF2FLAG_TALKING & ~FF2FLAG_ALLOWSPAWNINBOSSTEAM & ~FF2FLAG_CHANGECVAR & ~FF2FLAG_ROCKET_JUMPING & FF2FLAG_USEBOSSTIMER & FF2FLAG_USINGABILITY
+#define FF2FLAG_ALLOW_BOSS_ROCKETJUMPING	(1<<16)		//Used to allow or disallow bosses to rocketjump
+#define FF2FLAGS_SPAWN				~FF2FLAG_UBERREADY & ~FF2FLAG_ISBUFFED & ~FF2FLAG_TALKING & ~FF2FLAG_ALLOWSPAWNINBOSSTEAM & ~FF2FLAG_CHANGECVAR & ~FF2FLAG_ROCKET_JUMPING & ~FF2FLAG_ALLOW_BOSS_ROCKETJUMPING & FF2FLAG_USEBOSSTIMER & FF2FLAG_USINGABILITY
 
 #if defined _FF2_included
  #endinput
@@ -27,7 +28,7 @@
 /**
  * Is Freak Fortress enabled?
  *
- * @return	False if FF2 is disabled
+ * @return		False if FF2 is disabled
  *			True if FF2 is enabled
  */
 native bool FF2_IsFF2Enabled();
@@ -35,23 +36,25 @@ native bool FF2_IsFF2Enabled();
 /**
  * Gets the version of FF2 running on the server
  *
- * @param version   An array of size 3 that will contain the major, minor, and stable version numbers respectively
- * @return			True if the server is running a dev version of FF2, false otherwise
+ * @param version	An array of size 3 that will contain the major, minor, and stable version numbers respectively
+ *
+ * @return		True if the server is running a dev version of FF2, false otherwise
  */
 native bool FF2_GetFF2Version(version[]=0);
 
 /**
  * Gets the version of the FF2 fork running on the server
  *
- * @param version   An array of size 3 that will contain the major, minor, and stable version numbers respectively
- * @return			True if the server has a sub name defined, false otherwise
+ * @param version	An array of size 3 that will contain the major, minor, and stable version numbers respectively
+ *
+ * @return		True if the server has a sub name defined, false otherwise
  */
 native bool FF2_GetForkVersion(fversion[]=0);
 
 /**
  * Gets current round state
  *
- * @return	0 - in setup
+ * @return		0 - in setup
  *			1 - round is in progress (due to a bug in arena mode, stalemate will also return 1)
  *			2 - someone wins
  */
@@ -61,7 +64,8 @@ native int FF2_GetRoundState();
  * Gets UserID of current Boss
  *
  * @param boss		Boss's index
- * @return			Userid of boss (-1 if Boss does not exist)
+ *
+ * @return		Userid of boss (-1 if Boss does not exist)
  */
 native int FF2_GetBossUserId(int boss=0);
 
@@ -69,25 +73,28 @@ native int FF2_GetBossUserId(int boss=0);
  * Gets the boss index of a client
  *
  * @param client	The client used to search for the boss index
- * @return			Boss index of that client.  If client is not boss, returns -1
+ *
+ * @return		Boss index of that client.  If client is not boss, returns -1
  */
 native int FF2_GetBossIndex(int client);
 
 /**
  * Gets current team of Boss
- * @return			Number of boss's team
+ *
+ * @return		Number of boss's team
  */
 native int FF2_GetBossTeam();
 
 /**
  * Gets the character name of the Boss
  *
- * @param boss	 			Boss's index
- * @param buffer			Buffer for boss' character name
+ * @param boss	 		Boss's index
+ * @param buffer		Buffer for boss' character name
  * @param bufferLength		Length of buffer string
- * @param bossMeaning		0 - "boss" parameter means index of current Boss
- *							1 - "boss" parameter means number of Boss in characters.cfg-1
- * @return					True if boss exists, false if not
+ * @param bossMeaning			0 - "boss" parameter means index of current Boss
+ *					1 - "boss" parameter means number of Boss in characters.cfg
+ *
+ * @return			True if boss exists, false if not
  */
 native bool FF2_GetBossSpecial(int boss=0, char[] buffer, int bufferLength, int bossMeaning=0);
 
@@ -95,7 +102,8 @@ native bool FF2_GetBossSpecial(int boss=0, char[] buffer, int bufferLength, int 
  * Gets the current health value of the Boss
  *
  * @param boss		Boss's index
- * @return			Current health of the Boss
+ *
+ * @return		Current health of the Boss
  */
 native int FF2_GetBossHealth(int boss=0);
 
@@ -104,6 +112,7 @@ native int FF2_GetBossHealth(int boss=0);
  *
  * @param boss		Boss's index
  * @param health	New health value
+ *
  * @noreturn
  */
 native void FF2_SetBossHealth(int boss, int health);
@@ -111,8 +120,9 @@ native void FF2_SetBossHealth(int boss, int health);
 /**
  * Gets the max health of the Boss
  *
- * @param boss	 	Boss's index
- * @return			Max health of the Boss
+ * @param boss		Boss's index
+ *
+ * @return		Max health of the Boss
  */
 native int FF2_GetBossMaxHealth(int boss=0);
 
@@ -121,6 +131,7 @@ native int FF2_GetBossMaxHealth(int boss=0);
  *
  * @param boss		Boss's index
  * @param health	New max health value
+ *
  * @noreturn
  */
 native void FF2_SetBossMaxHealth(int boss, int health);
@@ -129,7 +140,8 @@ native void FF2_SetBossMaxHealth(int boss, int health);
  * Gets the current number of lives of the Boss
  *
  * @param boss		Boss's index
- * @return 			Number of lives the boss has remaining
+ *
+ * @return 		Number of lives the boss has remaining
  */
 native int FF2_GetBossLives(int boss);
 
@@ -138,6 +150,7 @@ native int FF2_GetBossLives(int boss);
  *
  * @param boss		Boss's index
  * @param lives		New number of lives
+ *
  * @noreturn
  */
 native void FF2_SetBossLives(int boss, int lives);
@@ -146,7 +159,8 @@ native void FF2_SetBossLives(int boss, int lives);
  * Gets the max number of lives of the Boss
  *
  * @param boss		Boss's index
- * @return			Max number of lives of the Boss
+ *
+ * @return		Max number of lives of the Boss
  */
 native int FF2_GetBossMaxLives(int boss);
 
@@ -155,6 +169,7 @@ native int FF2_GetBossMaxLives(int boss);
  *
  * @param boss		Boss's index
  * @param lives		New max number of lives
+ *
  * @noreturn
  */
 native void FF2_SetBossMaxLives(int boss, int lives);
@@ -164,10 +179,11 @@ native void FF2_SetBossMaxLives(int boss, int lives);
  *
  * @param boss		Boss's index
  * @param slot		Slot of charge meter
- *						0 - rage
- *						1 - as usual, used for brave jump or teleport
- *						2 - other charged abilities
- * @return			Charge value of the Boss
+ *				0 - rage
+ *				1 - as usual, used for brave jump or teleport
+ *				2 - other charged abilities
+ *
+ * @return		Charge value of the Boss
  */
 native float FF2_GetBossCharge(int boss, int slot);
 
@@ -176,10 +192,11 @@ native float FF2_GetBossCharge(int boss, int slot);
  *
  * @param boss		Boss's index
  * @param slot		Slot of charge meter
- *						0 - rage
- *						1 - as usual, used for brave jump or teleport
- *						2 - other charged abilities
+ *				0 - rage
+ *				1 - as usual, used for brave jump or teleport
+ *				2 - other charged abilities
  * @param value		New value of charge
+ *
  * @noreturn
  */
 native void FF2_SetBossCharge(int boss, int slot, float value);
@@ -187,7 +204,8 @@ native void FF2_SetBossCharge(int boss, int slot, float value);
 /**
  * Gets how much damage is needed in order to activate the rage of the current boss
  *
- * @param boss	Boss index
+ * @param boss		Boss index
+ *
  * @return		Total damage needed
  */
 native int FF2_GetBossRageDamage(int boss);
@@ -197,6 +215,7 @@ native int FF2_GetBossRageDamage(int boss);
  *
  * @param boss		Boss index
  * @param damage	New damage value
+ *
  * @noreturn
  */
 native void FF2_SetBossRageDamage(int boss, int damage);
@@ -205,44 +224,48 @@ native void FF2_SetBossRageDamage(int boss, int damage);
  * Gets damage dealt by this client
  *
  * @param client 	Client's index
- * @return			Damage dealt
+ *
+ * @return		Damage dealt
  */
 native int FF2_GetClientDamage(int client);
 
 /**
  * Gets an ability's rage distance
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName	Name of ability (use null string if you want get boss's global "ragedist" value)
- * @return				Ability's rage distance
+ *
+ * @return		Ability's rage distance
  */
 native float FF2_GetRageDist(int boss=0, const char[] pluginName="", const char[] abilityName="");
 
 /**
  * Finds if a Boss has a certain ability
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @return				True if the boss has this ability, false if it doesn't
+ *
+ * @return		True if the boss has this ability, false if it doesn't
  */
 native int FF2_HasAbility(int boss, const char[] pluginName, const char[] abilityName);
 
 /**
  * Determines how the Boss should use a certain ability
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @param slot			Slot of charge meter
- *							0 - rage
- *							1 - as usual, used for brave jump or teleport
- *							2 - other charged abilities
+ * @param slot		Slot of charge meter
+ *				0 - rage
+ *				1 - as usual, used for brave jump or teleport
+ *				2 - other charged abilities
  * @param buttonMode	How to activate the ability
- *							0 - by call for medic
- *							1 - by right mouse button or duck
- *							2 - by reload button
+ *				0 - by call for medic
+ *				1 - by right mouse button or duck
+ *				2 - by reload button
+ *
  * @noreturn
  */
 native void FF2_DoAbility(int boss, const char[] pluginName, const char[] abilityName, int slot, int buttonMode=0);
@@ -250,36 +273,39 @@ native void FF2_DoAbility(int boss, const char[] pluginName, const char[] abilit
 /**
  * Gets the integer value of an ability argument
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @param argument 		Number of argument
- * @param defValue 		Returns if argument is not defined
- * @return				Value of argument
+ * @param argument 	Number of argument
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @return		Value of argument
  */
 native int FF2_GetAbilityArgument(int boss, const char[] pluginName, const char[] abilityName, int argument, int defValue=0);
 
 /**
  * Gets the float value of an ability argument
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @param argument 		Number of argument
- * @param defValue 		Returns if argument is not defined
- * @return				Value of argument
+ * @param argument 	Number of argument
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @return		Value of argument
  */
 native float FF2_GetAbilityArgumentFloat(int boss, const char[] plugin_name, const char[] ability_name, int argument, float defValue=0.0);
 
 /**
  * Gets the string value of an ability argument
  *
- * @param boss			Boss's index
+ * @param boss		Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @param argument 		Number of argument
- * @param buffer 		Buffer for value of argument
+ * @param argument 	Number of argument
+ * @param buffer 	Buffer for value of argument
  * @param bufferLength	Length of buffer string
+ *
  * @noreturn
  */
 native void FF2_GetAbilityArgumentString(int boss, const char[] pluginName, const char[] abilityName, int argument, char[] buffer, int bufferLength);
@@ -287,12 +313,13 @@ native void FF2_GetAbilityArgumentString(int boss, const char[] pluginName, cons
 /**
  * Starts a random Boss sound from its config file
  *
- * @param keyvalue		Name of sound container
- * @param buffer		Buffer for result sound path
+ * @param keyvalue	Name of sound container
+ * @param buffer	Buffer for result sound path
  * @param bufferLength	Length of buffer
- * @param boss			Boss's index
- * @param slot			Only for "sound_ability" - slot of ability
- * @return				True if sound has been found, false otherwise
+ * @param boss		Boss's index
+ * @param slot		Only for "sound_ability" - slot of ability
+ *
+ * @return		True if sound has been found, false otherwise
  */
 native bool FF2_RandomSound(const char[] keyvalue, char[] buffer, int bufferLength, int boss=0, int slot=0);
 
@@ -300,6 +327,7 @@ native bool FF2_RandomSound(const char[] keyvalue, char[] buffer, int bufferLeng
  * Starts the Boss's music for the specified clients
  *
  * @param client	Client's index (0 for all clients)
+ *
  * @noreturn
  */
 native void FF2_StartMusic(int client=0);
@@ -308,6 +336,7 @@ native void FF2_StartMusic(int client=0);
  * Stops the Boss's music for the specified clients
  *
  * @param client	Client's index (0 for all clients)
+ *
  * @noreturn
  */
 native void FF2_StopMusic(int client=0);
@@ -315,10 +344,11 @@ native void FF2_StopMusic(int client=0);
 /**
  * Gets a Boss's KV handle
  *
- * @param boss				Boss's index
+ * @param boss		Boss's index
  * @param specialIndex		0 - 'boss' parameter refers to the index of the boss
- *							1 - 'boss' parameter refers to the index of the boss in characters.cfg-1
- * @return					Handle of Boss's keyvalues
+ *				1 - 'boss' parameter refers to the index of the boss in characters.cfg
+ *
+ * @return		Handle of Boss's keyvalues
  */
 native Handle FF2_GetSpecialKV(int boss, int specialIndex=0);
 
@@ -326,7 +356,8 @@ native Handle FF2_GetSpecialKV(int boss, int specialIndex=0);
  * Gets a client's flags for FF2
  *
  * @param client	Client's index
- * @return			Client's FF2 flags
+ *
+ * @return		Client's FF2 flags
  */
 native int FF2_GetFF2flags(int client);
 
@@ -335,6 +366,7 @@ native int FF2_GetFF2flags(int client);
  *
  * @param client	Client's index
  * @param flags		New flag values
+ *
  * @noreturn
  */
 native void FF2_SetFF2flags(int client, int flags);
@@ -343,6 +375,7 @@ native void FF2_SetFF2flags(int client, int flags);
  * Gets a client's queue points
  *
  * @param client	Client's index
+ *
  * @return			Client's queue points
  */
 native int FF2_GetQueuePoints(int client);
@@ -352,6 +385,7 @@ native int FF2_GetQueuePoints(int client);
  *
  * @param client	Client's index
  * @param value		New value of client's queue points
+ *
  * @noreturn
  */
 native void FF2_SetQueuePoints(int client, int value);
@@ -360,7 +394,8 @@ native void FF2_SetQueuePoints(int client, int value);
  * Gets a client's glow timer
  *
  * @param client	Client's index
- * @return			Number of seconds left until client glow disappears (-1 if invalid client)
+ *
+ * @return		Number of seconds left until client glow disappears (-1 if invalid client)
  */
 native int FF2_GetClientGlow(int client);
 
@@ -370,6 +405,7 @@ native int FF2_GetClientGlow(int client);
  * @param client	Client's index
  * @param time1		Number of seconds to add to the glow timer (can be negative)
  * @param time2		New value of glow timer
+ *
  * @noreturn
  */
 native void FF2_SetClientGlow(int client, float time1, float time2=-1.0);
@@ -378,7 +414,8 @@ native void FF2_SetClientGlow(int client, float time1, float time2=-1.0);
  * Gets a client's shield status
  *
  * @param client	Client's index
- * @return			Shield's health out of 100 (0 if shield is broken, -1 if not equipped)
+ *
+ * @return		Shield's health out of 100 (0 if shield is broken, -1 if not equipped)
  */
 native float FF2_GetClientShield(int client);
 
@@ -389,6 +426,7 @@ native float FF2_GetClientShield(int client);
  * @param entity	Shield entity
  * @param health	Shield's health out of 100
  * @param reduction	Shield's damage reduction
+ *
  * @noreturn
  */
 native void FF2_SetClientShield(int client, int entity=0, float health=-1.0, float reduction=-1.0);
@@ -397,6 +435,7 @@ native void FF2_SetClientShield(int client, int entity=0, float health=-1.0, flo
  * Removes a client's shield
  *
  * @param client	Client's index
+ *
  * @noreturn
  */
 native void FF2_RemoveClientShield(int client);
@@ -404,14 +443,16 @@ native void FF2_RemoveClientShield(int client);
 /**
  * Reports an error to FF2's error log
  *
- * @param message		Message to error log
+ * @param message	Message to error log
+ *
  * @noreturn
  */
 native void FF2_LogError(const char[] message, any ...);
 
 /**
  * Returns whether or not debug is enabled
- * @return			True if enabled, false otherwise
+ *
+ * @return		True if enabled, false otherwise
  */
 native bool FF2_Debug();
 
@@ -419,6 +460,7 @@ native bool FF2_Debug();
  * Sets the cheat status to turn of logging and statistics
  *
  * @param status	Disable statistics if true
+ *
  * @noreturn
  */
 native void FF2_SetCheats(bool status);
@@ -437,15 +479,16 @@ native bool FF2_GetCheats();
  *
  * Use FF2_PreAbility with enabled=false ONLY to prevent FF2_OnAbility!
  *
- * @param boss	 		Boss's index
+ * @param boss	 	Boss's index
  * @param pluginName	Name of plugin with this ability
  * @param abilityName 	Name of ability
- * @param slot			Slot of ability (THIS DOES NOT RETURN WHAT YOU THINK IT RETURNS FOR FF2_ONABILITY-if you insist on using this, refer to freak_fortress_2.sp to see what it actually does)
- * 							0 - Rage or life-loss
- * 							1 - Jump or teleport
- * 							2 - Other
- * @param status		Status of ability (DO NOT ACCESS THIS.  IT DOES NOT EXIST AND MIGHT CRASH YOUR SERVER)
- * @return				Plugin_Stop can not prevent the ability. Use FF2_PreAbility with enabled=false
+ * @param slot		Slot of ability (THIS DOES NOT RETURN WHAT YOU THINK IT RETURNS FOR FF2_ONABILITY-if you insist on using this, refer to freak_fortress_2.sp to see what it actually does)
+ * 				0 - Rage or life-loss
+ * 				1 - Jump or teleport
+ * 				2 - Other
+ * @param status	Status of ability (DO NOT ACCESS THIS.  IT DOES NOT EXIST AND MIGHT CRASH YOUR SERVER)
+ *
+ * @return		Plugin_Stop can not prevent the ability. Use FF2_PreAbility with enabled=false
  */
 forward int FF2_PreAbility(int boss, const char[] pluginName, const char[] abilityName, int slot, bool &enabled);
 forward Action FF2_OnAbility(int boss, const char[] pluginName, const char[] abilityName, int slot, int status);
@@ -453,19 +496,21 @@ forward Action FF2_OnAbility(int boss, const char[] pluginName, const char[] abi
 /**
  * Called when a Boss gets hurt by environmental damage
  *
- * @param boss	 		Boss's index
+ * @param boss	 	Boss's index
  * @param triggerHurt	Entity index of "trigger_hurt"
- * @param damage 		Damage by "trigger_hurt".  Cutomizable.
- * @return				Plugin_Stop will prevent forward, Plugin_Changed will change damage.
+ * @param damage 	Damage by "trigger_hurt".  Cutomizable.
+ *
+ * @return		Plugin_Stop will prevent forward, Plugin_Changed will change damage.
  */
 forward Action FF2_OnTriggerHurt(int boss, int triggerHurt, float &damage);
 
 /**
  * Called when a Boss's music begins
  *
- * @param path 			Path to music sound file
- * @param time			Length of music
- * @return				Plugin_Stop will prevent music, Plugin_Changed will change it.
+ * @param path 		Path to music sound file
+ * @param time		Length of music
+ *
+ * @return		Plugin_Stop will prevent music, Plugin_Changed will change it.
  */
 forward Action FF2_OnMusic(char[] path, float &time);
 
@@ -473,11 +518,12 @@ forward Action FF2_OnMusic(char[] path, float &time);
 /**
  * Called when FF2 picks a character for a Boss
  *
- * @param boss			Boss index
+ * @param boss		Boss index
  * @param character   	Character index
  * @param characterName	Character name
- * @param preset		True if the boss was set using a command such as ff2_special
- * @return				You can NOT use Plugin_Stop to prevent this, but you can change characterName and use Plugin_Changed to change the boss.  If you want to change 'character', then make 'characterName' null.
+ * @param preset	True if the boss was set using a command such as ff2_special
+ *
+ * @return		You can NOT use Plugin_Stop to prevent this, but you can change characterName and use Plugin_Changed to change the boss.  If you want to change 'character', then make 'characterName' null.
  */
 forward Action FF2_OnSpecialSelected(int boss, int &character, char[] characterName, bool preset);
 
@@ -486,7 +532,7 @@ forward Action FF2_OnSpecialSelected(int boss, int &character, char[] characterN
  *
  * @param add_points	Array that contains each player's queue points
  *
- * @return	Plugin_Stop will prevent this, Plugin_Changed will change it.
+ * @return		Plugin_Stop will prevent this, Plugin_Changed will change it.
  */
 forward Action FF2_OnAddQueuePoints(int add_points[MAXPLAYERS+1]);
 
@@ -495,7 +541,8 @@ forward Action FF2_OnAddQueuePoints(int add_points[MAXPLAYERS+1]);
  *
  * @param charSetNum	Number of character set
  * @param charSetName	Name of character set
- * @return				You can NOT use Plugin_Stop to prevent this, but you can change charSetName and use Plugin_Changed to change the character set.  If you want to change charSetNum, then make charSetName null.
+ *
+ * @return		You can NOT use Plugin_Stop to prevent this, but you can change charSetName and use Plugin_Changed to change the character set.  If you want to change charSetNum, then make charSetName null.
  */
 forward Action FF2_OnLoadCharacterSet(int &charSetNum, char[] charSetName);
 
@@ -505,7 +552,8 @@ forward Action FF2_OnLoadCharacterSet(int &charSetNum, char[] charSetName);
  * @param boss		Boss's index
  * @param lives		Number of lives left
  * @param maxLives	Max number of lives
- * @return			Plugin_Stop or Plugin_Handled to prevent damage that would remove a life, Plugin_Changed if you want to change the number of lives left.
+ *
+ * @return		Plugin_Stop or Plugin_Handled to prevent damage that would remove a life, Plugin_Changed if you want to change the number of lives left.
  */
 forward Action FF2_OnLoseLife(int boss, int &lives, int maxLives);
 
@@ -514,35 +562,36 @@ forward Action FF2_OnLoseLife(int boss, int &lives, int maxLives);
  *
  * @param players	Number of alive players left on the non-boss team
  * @param bosses	Number of alive players left on the boss team (this includes minions as well)
+ *
  * @noreturn
  */
 forward Action FF2_OnAlivePlayersChanged(int players, int bosses);
 
 /**
- *
  * Gives ammo to a weapon
  *
  * @param client	Client's index
  * @param weapon	Weapon
  * @param ammo		Ammo (set to 1 for clipless weapons, then set the actual ammo using clip)
  * @param clip		Clip
+ *
  * @noreturn
  */
 stock void FF2_SetAmmo(int client, int weapon, int ammo=-1, int clip=-1)
 {
 	if(IsValidEntity(weapon))
 	{
-		if(clip>-1)
+		if(clip > -1)
 		{
 			SetEntProp(weapon, Prop_Data, "m_iClip1", clip);
 		}
 
-		int ammoType=(ammo>-1 ? GetEntProp(weapon, Prop_Send, "m_iPrimaryAmmoType") : -1);
-		if(ammoType!=-1)
+		int ammoType = (ammo>-1 ? GetEntProp(weapon, Prop_Send, "m_iPrimaryAmmoType") : -1);
+		if(ammoType != -1)
 		{
 			SetEntProp(client, Prop_Data, "m_iAmmo", ammo, _, ammoType);
 		}
-		else if(ammo>-1)  //Only complain if we're trying to set ammo
+		else if(ammo > -1)  //Only complain if we're trying to set ammo
 		{
 			char classname[64], bossName[32];
 			GetEdictClassname(weapon, classname, sizeof(classname));
@@ -591,6 +640,7 @@ stock void FF2_ShowHudText(int client, int channel, const char[] buffer, any ...
  *
  * @param buffer	Debug string to display
  * @param any:...	Formatting rules
+ *
  * @noreturn
  */
 stock void Debug(char[] buffer, any ...)
@@ -632,7 +682,7 @@ stock void FPrintToChatAll(const char[] message, any ...)
 {
 	CCheckTrie();
 	char buffer[MAX_BUFFER_LENGTH], buffer2[MAX_BUFFER_LENGTH];
-	for(int i = 1; i <= MaxClients; i++)
+	for(int i=1; i<=MaxClients; i++)
 	{
 		if(!IsClientInGame(i) || CSkipList[i])
 		{
@@ -663,14 +713,14 @@ stock void FReplyToCommand(int client, const char[] message, any ...)
 	}
 }
 
-public SharedPlugin __pl_FF2=
+public SharedPlugin __pl_FF2 =
 {
-	name="freak_fortress_2",
-	file="freak_fortress_2.smx",
+	name = "freak_fortress_2",
+	file = "freak_fortress_2.smx",
 	#if defined REQUIRE_PLUGIN
-		required=1,
+		required = 1,
 	#else
-		required=0,
+		required = 0,
 	#endif
 };
 


### PR DESCRIPTION
Bug Fix Update
- #59 Fixed Health HUD being multiplied by the client's index
- #56 Fixed not being able to heal bosses at all
- Adjusted default ConVar values
- Added option in ff2_enabled to bypass maps.cfg
- ff2_point_alive, ff2_countdown_players, ff2_last_player_glow can set to be a players total to players alive ratio
- Ullapool Caber detonations left message doesn't appear when only one explosion is available
- Alias FF2FLAG_ALLOW_BOSS_ROCKETJUMPING for self knockback
- Points earned from damage message is rounded down
- sound_stabbed and sound_marketed don't infer with death or lifeloss sounds