### PR TITLE
[Update] 1.19.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Ｕｎｏｆｆｉｃｉａｌ　Ｆｒｅａｋ　Ｆｏｒｔｒｅｓｓ
-## A mixture of various popular plugins for FF2 and extra setting to give the best out of bosses and community servers!
+## A mixture of various popular plugins for FF2 and extra settings to give the best out of bosses and community servers!
 
 ### Installiton and Setup:
-The download does not include boss configs, models, or subplugins. It is recommended that you install the [offical Freak Fortress 1.10.14](https://github.com/50DKP/FF2-Official/releases/tag/1.10.14 "Release FF2 1.10.14 · 50DKP/FF2-Official") bosses and subpugins before installing this edit. **To install this edit, download 'Source code' in releases** This edit generates some new cvars, so save a backup of cfg/sourcemod/FreakFortress2.cfg and delete it, it will generate new cvars. **Notes:**                                             
-**All non-boss config (eg. characters.cfg, doors.cfg, and maps.cfg) need to go in data/freak_fortress_2/**                         
-**This has it's own boss selection and toggle menu, if you wish to disable, see cfg/sourcemod/FreakFortress2.cfg**                 
-**Always make sure to restart your server when applying updates or installing**
+To download Unofficial, download 'Source code' in releases, 'Resources' for boss models, materials, and sounds.                
+This generates some new ConVars, so save a backup of cfg/sourcemod/FreakFortress2.cfg and delete it, it will generate new ConVars.
+All non-boss config (`characters.cfg`, `doors.cfg`, `maps.cfg`) need to go in `data/freak_fortress_2/`.                          
+If your upgrading from official verions or applying a major update, restart your server!
 
-### Edit Changes:
-Visit the [Wiki tab](https://github.com/Batfoxkid/FreakFortressBat/wiki "Home · Batfoxkid/FreakFortressBat Wiki") to see a full list of changes. It will include cvars, boss settings, and other information.
+### Fork Changes:
+Visit the [Wiki tab](https://github.com/Batfoxkid/FreakFortressBat/wiki "Home · Batfoxkid/FreakFortressBat Wiki") to see a full list of changes. It will include ConVars, boss settings, and other information.
 
 ### Reporting Issues:
 Visit the [Issues tab](https://github.com/Batfoxkid/FreakFortressBat/issues "Issues · Batfoxkid/FreakFortressBat") to report any bugs, enhancements, or questions you may have. [Here's an template.](https://github.com/Batfoxkid/FreakFortressBat/blob/master/CONTRIBUTING.md "FreakFortressBat/CONTRIBUTING.md at master · Batfoxkid/FreakFortressBat")
@@ -17,8 +17,11 @@ Visit the [Issues tab](https://github.com/Batfoxkid/FreakFortressBat/issues "Iss
 SHADoW NiNE TR3S for FreakFortressBBG (and I use most of the code from)                                                
 [GitHub Profile](https://github.com/shadow93 "shadow93 (Koishi)") | [GitHub Repository](https://github.com/shadow93/FreakFortressBBG "shadow93/FreakFortressBBG: Fork formally used by Big Bang Gamers prior to its closing in November 2016.")
 
-Marxvee for healing, look-based teammate stats HUD, and spies disguising as bosses                                              
+Marxvee for healing, look-based teammate stats HUD, spies disguising as bosses, and backstab animation fix                       
 [Steam Profile](https://steamcommunity.com/profiles/76561198299989625/ "Steam Community :: marxvee❤")
+
+naydef for newer versions of official Freak Fortress                                                                     
+[GitHub Profile](https://github.com/naydef "naydef") | [GitHub Repository](https://github.com/naydef/FF2-Official/tree/stable "naydef/FF2-Official at stable")
 
 MAGNAT2645 for Russian translations and pointing out errors                                                    
 [GitHub Profile](https://github.com/MAGNAT2645 "MAGNAT2645 (MAGNAT2645)")
@@ -29,8 +32,11 @@ sarysa for the improved stun code
 Bacon Plague and M76030 for their boss self-knockback code                                                                         
 [Bacon Plague's Steam Profile](https://steamcommunity.com/profiles/76561198049884052/) | [M76030's GitHub Profile](https://github.com/M76030 "M76030")
 
+JuegosPablo for skip a boss turn code                                                                           
+[AlliedModders Profile](https://forums.alliedmods.net/member.php?u=268021 "AlliedModders - View Profile: JuegosPablo")
+
 Deathreus for the current boss in server name                                                                                      
 [GitHub Profile](https://github.com/Deathreus "Deathreus") | [GitHub Commit](https://github.com/Deathreus/FF2-Official/commit/f023069f3cd2afafb69f895106ea37f7cff9745b "Change hostname to append the boss name · Deathrus/FF2-Official@f023069")
 
-And the FF2 team                                                                                                                   
+And the original FF2 team(s)                                                                                              
 [GitHub Repository](https://github.com/50DKP/FF2-Official "50DKP/FF2-Official: Freak Fortress 2 is a one versus all mod for Team Fortress 2. It is the successor to the Vs. Saxton Hale plugin.")

--- a/README.txt
+++ b/README.txt
@@ -1,18 +1,14 @@
                                   -=-=- Ｕｎｏｆｆｉｃｉａｌ　Ｆｒｅａｋ　Ｆｏｒｔｒｅｓｓ -=-=-
-  -=- A mixture of various popular plugins for FF2 and extra setting to give the best out of bosses and community servers -=-
+  -=- A mixture of various popular plugins for FF2 and extra settings to give the best out of bosses and community servers -=-
 
 ### Installiton and Setup:
-The download does not include boss configs, models, or subplugins. It is recommended that you install the offical Freak Fortress
-1.10.14 (https://github.com/50DKP/FF2-Official/releases/tag/1.10.14) bosses and subpugins before installing this edit. To install
-this edit, download 'Source code' in releases. This edit generates some new cvars, so save a backup of
-cfg/sourcemod/FreakFortress2.cfg and delete it, it will generate new cvars. Notes:
+To download Unofficial, download 'Source code' in releases, 'Resources' for boss models, materials, and sounds.
+This generates some new ConVars, so save a backup of cfg/sourcemod/FreakFortress2.cfg and delete it, it will generate new ConVars.
+All non-boss config (`characters.cfg`, `doors.cfg`, `maps.cfg`) need to go in `data/freak_fortress_2/`.
+If your upgrading from official verions or applying a major update, restart your server!
 
--= All non-boss config (eg. characters.cfg, doors.cfg, and maps.cfg) need to go in addons/sourcemod/data/freak_fortress_2/ =-
--=   This has it's own boss selection and toggle menu, if you wish to disable these see cfg/sourcemod/FreakFortress2.cfg   =-
-                   -=    Always make sure to restart your server when applying updates or installing    =-
-
--=- Edit Changes -=-
-Visit the Wiki tab (https://github.com/Batfoxkid/FreakFortressBat/wiki) to see a full list of changes. It will include cvars, boss
+-=- Fork Changes -=-
+Visit the Wiki tab (https://github.com/Batfoxkid/FreakFortressBat/wiki) to see a full list of changes. It will include ConVars, boss
 settings, and other information.
 
 -=- Reporting Issues -=-
@@ -23,8 +19,11 @@ have. Please try to avoid spam and nonsense.
 SHADoW NiNE TR3S for FreakFortressBBG (and I use most of the code from)
 https://github.com/shadow93 | https://github.com/shadow93/FreakFortressBBG
 
-Marxvee for healing, look-based teammate stats HUD, and spies disguising as bosses
+Marxvee for healing, look-based teammate stats HUD, spies disguising as bosses, and backstab animation fix
 https://steamcommunity.com/profiles/76561198299989625/
+
+naydef for newer versions of official Freak Fortress
+https://github.com/naydef | https://github.com/naydef/FF2-Official/tree/stable
 
 MAGNAT2645 for Russian translations and pointing out errors
 https://github.com/MAGNAT2645
@@ -35,8 +34,11 @@ https://github.com/sarysa | https://forums.alliedmods.net/showthread.php?t=30924
 Bacon Plague and M76030 for their boss self-knockback code
 https://steamcommunity.com/profiles/76561198049884052/ | https://github.com/M76030
 
+JuegosPablo for skip a boss turn code
+https://forums.alliedmods.net/member.php?u=268021
+
 Deathreus for the current boss in server name
 https://github.com/Deathreus | https://github.com/Deathreus/FF2-Official
 
-And the FF2 team
+And the original FF2 team(s)
 https://github.com/50DKP/FF2-Official

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."003"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."004"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -11457,12 +11457,6 @@ public Action OnPlayerHurt(Handle event, const char[] name, bool dontBroadcast)
 		int health = GetClientHealth(client);
 		switch(GetConVarInt(cvarShieldType))
 		{
-			case 1:
-			{
-				SetEntityHealth(client, preHealth);
-				RemoveShield(client, attacker);
-				return Plugin_Handled;
-			}
 			case 2:
 			{
 				if(preHealth <= damage)
@@ -11863,6 +11857,12 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 			{
 				damage *= 0.25;
 				return Plugin_Changed;
+			}
+
+			if(GetConVarInt(cvarShieldType) == 1)
+			{
+				RemoveShield(client, attacker);
+				return Plugin_Handled;
 			}
 
 			if(damage<=160.0 && dmgTriple[attacker])

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -15200,10 +15200,52 @@ public Action HelpPanelClass(int client)
 		return Plugin_Continue;
 	}
 
-	#if SOURCEMOD_V_MAJOR==1 && SOURCEMOD_V_MINOR>8
-	char translation[64], text[512];
+	char text[512];
 	TFClassType class = TF2_GetPlayerClass(client);
 	SetGlobalTransTarget(client);
+	#if SOURCEMOD_V_MAJOR==1 && SOURCEMOD_V_MINOR<=8
+	switch(class)
+	{
+		case TFClass_Scout:
+			Format(text, sizeof(text), "%t", "help_scout");
+
+		case TFClass_Soldier:
+			Format(text, sizeof(text), "%t", "help_soldier");
+
+		case TFClass_Pyro:
+			Format(text, sizeof(text), "%t", "help_pyro");
+
+		case TFClass_DemoMan:
+			Format(text, sizeof(text), "%t", "help_demo");
+
+		case TFClass_Heavy:
+			Format(text, sizeof(text), "%t", "help_heavy");
+
+		case TFClass_Engineer:
+			Format(text, sizeof(text), "%t", "help_eggineer");
+
+		case TFClass_Medic:
+			Format(text, sizeof(text), "%t", "help_medic");
+
+		case TFClass_Sniper:
+			Format(text, sizeof(text), "%t", "help_sniper");
+
+		case TFClass_Spy:
+			Format(text, sizeof(text), "%t", "help_spie");
+
+		default:
+			Format(text, sizeof(text), "");
+	}
+
+	Format(text, sizeof(text), "%t\n%s", "help_melee", text);
+	Handle panel = CreatePanel();
+	SetPanelTitle(panel, text);
+	Format(text, sizeof(text), "%t", "Exit");
+	DrawPanelItem(panel, text);
+	SendPanelToClient(panel, client, HintPanelH, 20);
+	CloseHandle(panel);
+	#else
+	char translation[64];
 	int weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Primary);
 	if(IsValidEntity(weapon))
 	{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."004"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -5402,7 +5402,7 @@ public Action Timer_CalcQueuePoints(Handle timer)
 
 			if(IsBoss(client))
 			{
-				if(((GetBossIndex(client)==0 && GetBossIndex(client)==MAXBOSSES) && GetConVarBool(cvarDuoRestore)) || !GetConVarBool(cvarDuoRestore))
+				if(((GetBossIndex(client)==0 || GetBossIndex(client)==MAXBOSSES) && GetConVarBool(cvarDuoRestore)) || !GetConVarBool(cvarDuoRestore))
 				{
 					add_points[client]=-QueuePoints[client];
 					add_points2[client]=add_points[client];
@@ -7416,7 +7416,7 @@ public Action Timer_MakeBoss(Handle timer, any boss)
 	HazardDamage[client] = 0.0;
 	BossKillsF[client] = BossKills[client];
 	HealthBarModeC[client] = false;
-	if((GetBossIndex(client)==0 && GetConVarBool(cvarDuoRestore)) || !GetConVarBool(cvarDuoRestore))
+	if(((GetBossIndex(client)==0 || GetBossIndex(client)==MAXBOSSES) && GetConVarBool(cvarDuoRestore)) || !GetConVarBool(cvarDuoRestore))
 	{
 		QueuePoints[client] = 0;
 	}

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -76,9 +76,9 @@ last time or to encourage others to do the same.
 #define FORK_MINOR_REVISION "19"
 #define FORK_STABLE_REVISION "2"
 #define FORK_SUB_REVISION "Unofficial"
-//#define FORK_DEV_REVISION "Build"
+#define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."007"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."000"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -308,7 +308,7 @@ ConVar cvarBvBChaos;
 ConVar cvarBvBMerc;
 ConVar cvarBvBStat;
 ConVar cvarTimesTen;
-//ConVar cvarShuffleCharset;
+ConVar cvarShuffleCharset;
 
 Handle FF2Cookies;
 Handle StatCookies;
@@ -2114,7 +2114,7 @@ public void OnPluginStart()
 	cvarBvBMerc = CreateConVar("ff2_boss_vs_boss_damage", "1.0", "How much to multiply non-boss damage against non-boss while each team as a boss alive", _, true, 0.0);
 	cvarBvBStat = CreateConVar("ff2_boss_vs_boss_stats", "0", "Should Boss vs Boss mode count towards StatTrak?", _, true, 0.0, true, 1.0);
 	cvarTimesTen = CreateConVar("ff2_times_ten", "5.0", "Amount to multiply boss's health and ragedamage when TF2x10 is enabled", _, true, 0.0);
-	//cvarShuffleCharset = CreateConVar("ff2_bosspack_vote", "0", "0-Random option and show all packs, #-Random amount of packs to choose", _, true, 0.0, true, 64.0);
+	cvarShuffleCharset = CreateConVar("ff2_bosspack_vote", "0", "0-Random option and show all packs, #-Random amount of packs to choose", _, true, 0.0, true, 64.0);
 
 	//The following are used in various subplugins
 	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
@@ -15897,10 +15897,10 @@ public Action Timer_DisplayCharsetVote(Handle timer)
 	Handle Kv = CreateKeyValues("");
 	FileToKeyValues(Kv, config);
 	int total, charsets;
-	/*int shuffle = GetConVarInt(cvarShuffleCharset);
+	int shuffle = GetConVarInt(cvarShuffleCharset);
 	if(!shuffle)
 		AddMenuItem(menu, "0", "Random");*/
-	AddMenuItem(menu, "0", "Random");
+
 	do
 	{
 		total++;
@@ -15911,57 +15911,34 @@ public Action Timer_DisplayCharsetVote(Handle timer)
 		validCharsets[charsets] = total;
 
 		KvGetSectionName(Kv, charset, sizeof(charset));
-		/*if(!shuffle)
+		if(!shuffle)
 		{
 			IntToString(total, index, sizeof(index));
 			AddMenuItem(menu, index, charset);
-		}*/
-		IntToString(total, index, sizeof(index));
-		AddMenuItem(menu, index, charset);
+		}
 	}
 	while(KvGotoNextKey(Kv));
 
-	/*if(shuffle && charsets>1)
+	if(shuffle && charsets>1)
 	{
 		KvRewind(Kv);
 
-		int choosen, current=-1;
-		for(int tries; tries<99; tries++)
+		int packs, current;
+		bool choosen[64];
+		for(int tries; tries<99 && packs<=shuffle; tries++)
 		{
-			if(tries > 97)
-			{
-				FF2Dbg("Last try %i", tries);
-			}
-
-			if(shuffle <= choosen)
-			{
-				FF2Dbg("Ended %i of %i filled", choosen, shuffle);
-				break;
-			}
-
-			if(!KvGotoNextKey(Kv))	// Move next pack
-			{
-				current = -1;
-				KvRewind(Kv);
-			}
-
-			if(KvGetNum(Kv, "hidden", 0))
+			current = validCharsets[GetRandomInt(1, charsets)]-1;
+			if(current<=0 || choosen[current])
 				continue;
 
-			current++;
-			if(validCharsets[current]<=0 || GetRandomInt(0, charsets)<(charsets-1))	// If it's valid (because of exclusion) and randomly choosen
-				continue;
-
-			choosen++;
-			FF2Dbg("Pack %i [%i] (%i of %i) chosen on try %i", current, validCharsets[current], choosen, shuffle, tries);
-
+			packs++;
+			choosen[current] = true;
+			KvJumpToKeySymbol(Kv, current);
 			KvGetSectionName(Kv, charset, sizeof(charset));
-			IntToString(validCharsets[current], index, sizeof(index));
+			IntToString(current, index, sizeof(index));
 			AddMenuItem(menu, index, charset);
-
-			validCharsets[current] = 0;	// Exclude from being picked twice
 		}
-	}*/
+	}
 	CloseHandle(Kv);
 
 	if(charsets > 1)  //We have enough to call a vote

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."002"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."003"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -5023,21 +5023,15 @@ public Action OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
 		}
 	}
 
-	if(!Enabled3)
-	{
-		SetConVarInt(FindConVar("mp_teams_unbalance_limit"), 0);
-		CreateTimer(bonusRoundTime, Timer_CheckBossVsBoss, _, TIMER_FLAG_NO_MAPCHANGE);
-	}
-
 	if(GetConVarInt(cvarBossVsBoss) > 0)
 	{
 		if(GetRandomInt(0, 99) < GetConVarInt(cvarBossVsBoss))
 		{
-			CreateTimer(bonusRoundTime-0.5, Timer_SetEnabled3, true, TIMER_FLAG_NO_MAPCHANGE);
+			CreateTimer(bonusRoundTime-0.1, Timer_SetEnabled3, true, TIMER_FLAG_NO_MAPCHANGE);
 		}
 		else
 		{
-			CreateTimer(bonusRoundTime-0.5, Timer_SetEnabled3, false, TIMER_FLAG_NO_MAPCHANGE);
+			CreateTimer(bonusRoundTime-0.1, Timer_SetEnabled3, false, TIMER_FLAG_NO_MAPCHANGE);
 		}
 	}
 	else
@@ -5081,28 +5075,29 @@ public Action OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
 public Action Timer_SetEnabled3(Handle timer, bool toggle)
 {
 	Enabled3 = toggle;
-	return Plugin_Continue;
-}
-
-public Action Timer_CheckBossVsBoss(Handle timer)
-{
-	if(!Enabled3)
-		return Plugin_Continue;
-
-	int team = OtherTeam;
-	for(int client=1; client<=MaxClients; client++)
+	if(Enabled3)
 	{
-		if(IsValidClient(client))
+		SetConVarInt(FindConVar("mp_teams_unbalance_limit"), 0);
+
+		//int team = OtherTeam;
+		for(int client=1; client<=MaxClients; client++)
 		{
-			if(!IsPlayerAlive(client) && GetClientTeam(client)>view_as<int>(TFTeam_Spectator))
+			if(IsValidClient(client))
 			{
-				ChangeClientTeam(client, team);
-				team = team==BossTeam ? OtherTeam : BossTeam;
+				if(!IsPlayerAlive(client) && GetClientTeam(client)>view_as<int>(TFTeam_Spectator))
+				{
+					//ChangeClientTeam(client, team);
+					//team = team==BossTeam ? OtherTeam : BossTeam;
+					FakeClientCommand(client, "autoteam");
+				}
 			}
 		}
-	}
 
-	SetConVarInt(FindConVar("mp_teams_unbalance_limit"), mp_teams_unbalance_limit);
+	}
+	else
+	{
+		SetConVarInt(FindConVar("mp_teams_unbalance_limit"), mp_teams_unbalance_limit);
+	}
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."006"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."007"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -208,8 +208,6 @@ float AirstrikeDamage[MAXTF2PLAYERS];
 float KillstreakDamage[MAXTF2PLAYERS];
 float HazardDamage[MAXTF2PLAYERS];
 bool emitRageSound[MAXTF2PLAYERS];
-bool bossHasReloadAbility[MAXTF2PLAYERS];
-bool bossHasRightMouseAbility[MAXTF2PLAYERS];
 bool SpawnTeleOnTriggerHurt = false;
 bool HealthBarMode;
 bool HealthBarModeC[MAXTF2PLAYERS];
@@ -3228,9 +3226,6 @@ public void DisableFF2()
 			KillTimer(MusicTimer[client]);
 			MusicTimer[client] = INVALID_HANDLE;
 		}
-
-		bossHasReloadAbility[client] = false;
-		bossHasRightMouseAbility[client] = false;
 	}
 
 	#if !defined _smac_included
@@ -4860,8 +4855,6 @@ public Action OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
 			{
 				BossCharge[client][slot] = 0.0;
 			}
-			bossHasReloadAbility[client] = false;
-			bossHasRightMouseAbility[client] = false;
 			SaveClientStats(client);
 		}
 		else if(IsValidClient(client))
@@ -16084,24 +16077,22 @@ bool UseAbility(const char[] ability_name, const char[] plugin_name, int boss, i
 		switch(buttonMode)
 		{
 			case 1:
-			{
 				button = IN_DUCK|IN_ATTACK2;
-				bossHasRightMouseAbility[boss] = true;
-			}
+
 			case 2:
-			{
 				button = IN_RELOAD;
-				bossHasReloadAbility[boss] = true;
-			}
+
 			case 3:
-			{
 				button = IN_ATTACK3;
-			}
+
+			case 4:
+				button = IN_DUCK;
+
+			case 5:
+				button = IN_SCORE;
+
 			default:
-			{	// I really don't want players relying on ducking
 				button = IN_ATTACK2;
-				bossHasRightMouseAbility[boss] = true;
-			}
 		}
 
 		if(GetClientButtons(Boss[boss]) & button)

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."006"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."007"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -775,7 +775,11 @@ stock void FindVersionData(Handle panel, int versionIndex)
 	{
 		case 152:  //1.19.3
 		{
-			DrawPanelText(panel, "1) TODO");
+			DrawPanelText(panel, "1) [Core] Fixed selecting companions being reset constantly (Batfoxkid)");
+			DrawPanelText(panel, "2) [Gameplay] Fixed, yet more issues in Boss vs Boss mode (Batfoxkid)");
+			DrawPanelText(panel, "3) [Bosses] Allowed pickup flags to be used on non-bosses (Batfoxkid)");
+			DrawPanelText(panel, "4) [Gameplay] Fixed rival bosses being comapnions in queue points (Batfoxkid)");
+			DrawPanelText(panel, "5) [Gameplay] Reworked class info to show information based on your loadout (Batfoxkid)");
 		}
 		case 151:  //1.19.2
 		{
@@ -2324,7 +2328,9 @@ public void OnPluginStart()
 	LoadTranslations("freak_fortress_2.phrases");
 	LoadTranslations("freak_fortress_2_prefs.phrases");
 	LoadTranslations("freak_fortress_2_stats.phrases");
+	LoadTranslations("freak_fortress_2_weaps.phrases");
 	LoadTranslations("common.phrases");
+	LoadTranslations("core.phrases");
 
 	if(LateLoaded)
 		OnMapStart();
@@ -15187,55 +15193,184 @@ public Action HelpPanelClass(int client)
 	if(!Enabled)
 		return Plugin_Continue;
 
-	int boss=GetBossIndex(client);
-	if(boss!=-1)
+	int boss = GetBossIndex(client);
+	if(boss != -1)
 	{
 		HelpPanelBoss(boss);
 		return Plugin_Continue;
 	}
 
-	char text[512];
-	TFClassType class=TF2_GetPlayerClass(client);
+	#if SOURCEMOD_V_MAJOR==1 && SOURCEMOD_V_MINOR>8
+	char translation[64], text[512];
+	TFClassType class = TF2_GetPlayerClass(client);
 	SetGlobalTransTarget(client);
-	switch(class)
+	int weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Primary);
+	if(IsValidEntity(weapon))
 	{
-		case TFClass_Scout:
-			Format(text, sizeof(text), "%T", "help_scout", client);
+		Format(translation, sizeof(translation), "primary_%i", GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"));
+		if(TranslationPhraseExists(translation))
+		{
+			Format(text, sizeof(text), "%t\n", translation);
+		}
+		else
+		{
+			switch(class)
+			{
+				case TFClass_Scout:
+					Format(text, sizeof(text), "%t\n", "primary_scout");
 
-		case TFClass_Soldier:
-			Format(text, sizeof(text), "%T", "help_soldier", client);
+				case TFClass_Soldier:
+					Format(text, sizeof(text), "%t\n", "primary_soldier");
 
-		case TFClass_Pyro:
-			Format(text, sizeof(text), "%T", "help_pyro", client);
+				case TFClass_Pyro:
+					Format(text, sizeof(text), "%t\n", "primary_pyro");
 
-		case TFClass_DemoMan:
-			Format(text, sizeof(text), "%T", "help_demo", client);
+				case TFClass_DemoMan:
+					Format(text, sizeof(text), "%t\n", "primary_demo");
 
-		case TFClass_Heavy:
-			Format(text, sizeof(text), "%T", "help_heavy", client);
+				case TFClass_Heavy:
+					Format(text, sizeof(text), "%t\n", "primary_heavy");
 
-		case TFClass_Engineer:
-			Format(text, sizeof(text), "%T", "help_eggineer", client);
+				case TFClass_Engineer:
+					Format(text, sizeof(text), "%t\n", "primary_engineer");
 
-		case TFClass_Medic:
-			Format(text, sizeof(text), "%T", "help_medic", client);
+				case TFClass_Medic:
+					Format(text, sizeof(text), "%t\n", "primary_medic");
 
-		case TFClass_Sniper:
-			Format(text, sizeof(text), "%T", "help_sniper", client);
+				case TFClass_Sniper:
+					Format(text, sizeof(text), "%t\n", "primary_sniper");
 
-		case TFClass_Spy:
-			Format(text, sizeof(text), "%T", "help_spie", client);
+				case TFClass_Spy:
+					Format(text, sizeof(text), "%t\n", "primary_spy");
 
-		default:
-			Format(text, sizeof(text), "");
+				default:
+					Format(text, sizeof(text), "%t\n", "primary_merc");
+			}
+		}
 	}
 
-	Format(text, sizeof(text), "%T\n%s", "help_melee", client, text);
-	Handle panel=CreatePanel();
-	SetPanelTitle(panel, text);
-	DrawPanelItem(panel, "Exit");
-	SendPanelToClient(panel, client, HintPanelH, 20);
-	CloseHandle(panel);
+	weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Secondary);
+	if(IsValidEntity(weapon))
+	{
+		Format(translation, sizeof(translation), "secondary_%i", GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"));
+		if(TranslationPhraseExists(translation))
+		{
+			Format(text, sizeof(text), "%s%t\n", text, translation);
+		}
+		else
+		{
+			switch(class)
+			{
+				case TFClass_Scout:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_scout");
+
+				case TFClass_Soldier:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_soldier");
+
+				case TFClass_Pyro:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_pyro");
+
+				case TFClass_DemoMan:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_demo");
+
+				case TFClass_Heavy:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_heavy");
+
+				case TFClass_Engineer:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_engineer");
+
+				case TFClass_Medic:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_medic");
+
+				case TFClass_Sniper:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_sniper");
+
+				case TFClass_Spy:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_spy");
+
+				default:
+					Format(text, sizeof(text), "%s%t\n", text, "secondary_merc");
+			}
+		}
+	}
+
+	weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Melee);
+	if(IsValidEntity(weapon))
+	{
+		Format(translation, sizeof(translation), "melee_%i", GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"));
+		if(TranslationPhraseExists(translation))
+		{
+			Format(text, sizeof(text), "%s%t\n", text, translation);
+		}
+		else
+		{
+			switch(class)
+			{
+				case TFClass_Scout:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_scout");
+
+				case TFClass_Soldier:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_soldier");
+
+				case TFClass_Pyro:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_pyro");
+
+				case TFClass_DemoMan:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_demo");
+
+				case TFClass_Heavy:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_heavy");
+
+				case TFClass_Engineer:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_engineer");
+
+				case TFClass_Medic:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_medic");
+
+				case TFClass_Sniper:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_sniper");
+
+				case TFClass_Spy:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_spy");
+
+				default:
+					Format(text, sizeof(text), "%s%t\n", text, "melee_merc");
+			}
+		}
+	}
+
+	weapon = GetPlayerWeaponSlot(client, TFWeaponSlot_Building);
+	if(IsValidEntity(weapon))
+	{
+		Format(translation, sizeof(translation), "pda_%i", GetEntProp(weapon, Prop_Send, "m_iItemDefinitionIndex"));
+		if(TranslationPhraseExists(translation))
+		{
+			Format(text, sizeof(text), "%s%t\n", text, translation);
+		}
+		else
+		{
+			switch(class)
+			{
+				case TFClass_Engineer:
+					Format(text, sizeof(text), "%s%t\n", text, "pda_engineer");
+
+				case TFClass_Spy:
+					Format(text, sizeof(text), "%s%t\n", text, "pda_spy");
+			}
+		}
+	}
+
+	if(strlen(text))
+	{
+		Format(text, sizeof(text), "%t\n\n%s", "info_title", text);
+		Handle panel = CreatePanel();
+		SetPanelTitle(panel, text);
+		Format(text, sizeof(text), "%t", "Exit");
+		DrawPanelItem(panel, text);
+		SendPanelToClient(panel, client, HintPanelH, 20);
+		CloseHandle(panel);
+	}
+	#endif
 	return Plugin_Continue;
 }
 
@@ -15258,9 +15393,10 @@ void HelpPanelBoss(int boss)
 	}
 	ReplaceString(text, sizeof(text), "\\n", "\n");
 
-	Handle panel=CreatePanel();
+	Handle panel = CreatePanel();
 	SetPanelTitle(panel, text);
-	DrawPanelItem(panel, "Exit");
+	Format(text, sizeof(text), "%T", "Exit", Boss[boss]);
+	DrawPanelItem(panel, text);
 	SendPanelToClient(panel, Boss[boss], HintPanelH, 20);
 	CloseHandle(panel);
 }
@@ -15302,7 +15438,7 @@ public Action MusicTogglePanel(int client)
 {
 	if(!GetConVarBool(cvarAdvancedMusic))
 	{
-		Handle panel=CreatePanel();
+		Handle panel = CreatePanel();
 		SetPanelTitle(panel, "Turn the Freak Fortress 2 music...");
 		DrawPanelItem(panel, "On");
 		DrawPanelItem(panel, "Off");

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."007"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."008"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -11943,7 +11943,7 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 				return Plugin_Changed;
 			}
 
-			if(GetConVarInt(cvarShieldType) == 1)
+			if(shield[client] && GetConVarInt(cvarShieldType)==1)
 			{
 				RemoveShield(client, attacker);
 				return Plugin_Handled;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 //#define FORK_DEV_REVISION "Build"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."006"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -16110,7 +16110,15 @@ bool UseAbility(const char[] ability_name, const char[] plugin_name, int boss, i
 			{
 				Call_PushCell(2);  //Status
 				Call_Finish(action);
-				float charge = 100.0*0.2/GetAbilityArgumentFloat(boss, plugin_name, ability_name, 1, 1.5);
+				if(GetArgumentI(boss, plugin_name, ability_name, "slot", -2) != -2)
+				{
+					charge = 100.0*0.2/GetArgumentF(boss, plugin_name, ability_name, "charge time", 1.5);
+				}
+				else
+				{
+					charge = 100.0*0.2/GetAbilityArgumentFloat(boss, plugin_name, ability_name, 1, 1.5);
+				}
+
 				if(BossCharge[boss][slot]+charge < 100.0)
 				{
 					BossCharge[boss][slot] += charge;
@@ -16139,7 +16147,14 @@ bool UseAbility(const char[] ability_name, const char[] plugin_name, int boss, i
 				CreateDataTimer(0.1, Timer_UseBossCharge, data);
 				WritePackCell(data, boss);
 				WritePackCell(data, slot);
-				WritePackFloat(data, -1.0*GetAbilityArgumentFloat(boss, plugin_name, ability_name, 2, 5.0));
+				if(GetArgumentI(boss, plugin_name, ability_name, "slot", -2) != -2)
+				{
+					WritePackFloat(data, -1.0*GetArgumentF(boss, plugin_name, ability_name, "cooldown", 5.0));
+				}
+				else
+				{
+					WritePackFloat(data, -1.0*GetAbilityArgumentFloat(boss, plugin_name, ability_name, 2, 5.0));
+				}
 				ResetPack(data);
 			}
 			else

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."006"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -16930,7 +16930,7 @@ public void OnItemSpawned(int entity)
 
 public Action OnPickup(int entity, int client)  //Thanks friagram!
 {
-	if(IsBoss(client))
+	if(Enabled)
 	{
 		char classname[32];
 		GetEntityClassname(entity, classname, sizeof(classname));

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -16110,6 +16110,7 @@ bool UseAbility(const char[] ability_name, const char[] plugin_name, int boss, i
 			{
 				Call_PushCell(2);  //Status
 				Call_Finish(action);
+				float charge;
 				if(GetArgumentI(boss, plugin_name, ability_name, "slot", -2) != -2)
 				{
 					charge = 100.0*0.2/GetArgumentF(boss, plugin_name, ability_name, "charge time", 1.5);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."004"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."005"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -6599,8 +6599,9 @@ stock int CreateAttachedAnnotation(int client, int entity, bool effect=true, flo
 	SetEventInt(event, "follow_entindex", entity);
 	SetEventFloat(event, "lifetime", time);
 	SetEventInt(event, "visibilityBitfield", (1<<client));
-	SetEventBool(event,"show_effect", effect);
+	SetEventBool(event, "show_effect", effect);
 	SetEventString(event, "text", message);
+	SetEventString(event, "play_sound", "vo/null.wav");
 	SetEventInt(event, "id", entity); //What to enter inside? Need a way to identify annotations by entindex!
 	FireEvent(event);
 	return entity;

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -78,7 +78,7 @@ last time or to encourage others to do the same.
 #define FORK_SUB_REVISION "Unofficial"
 #define FORK_DEV_REVISION "development"
 
-#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."001"
+#define BUILD_NUMBER FORK_MINOR_REVISION...""...FORK_STABLE_REVISION..."002"
 
 #if !defined FORK_DEV_REVISION
 	#define PLUGIN_VERSION FORK_SUB_REVISION..." "...FORK_MAJOR_REVISION..."."...FORK_MINOR_REVISION..."."...FORK_STABLE_REVISION
@@ -9732,7 +9732,7 @@ public Action ClientTimer(Handle timer)
 					FF2flags[client]&=~FF2FLAG_ISBUFFED;
 			}
 
-			int aliveTeammates = Enabled3 ? BossAlivePlayers+MercAlivePlayers-3 : MercAlivePlayers;
+			int aliveTeammates = Enabled3 ? BossAlivePlayers+MercAlivePlayers-1 : MercAlivePlayers;
 
 			if(lastPlayerGlow > 0)
 			{
@@ -10145,7 +10145,7 @@ public Action BossTimer(Handle timer)
 			ActivateAbilitySlot(boss, i, true);
 		}
 
-		int aliveTeammates = Enabled3 ? BossAlivePlayers+MercAlivePlayers-3 : MercAlivePlayers;
+		int aliveTeammates = Enabled3 ? BossAlivePlayers+MercAlivePlayers-1 : MercAlivePlayers;
 
 		if(lastPlayerGlow > 0)
 		{
@@ -11178,7 +11178,7 @@ public Action Timer_CheckAlivePlayers(Handle timer)
 		LastMan=false;
 	}
 
-	float alivePlayers = Enabled3 ? float(MercAlivePlayers + BossAlivePlayers - 3) : float(MercAlivePlayers);
+	float alivePlayers = Enabled3 ? float(MercAlivePlayers + BossAlivePlayers - 1) : float(MercAlivePlayers);
 	if(countdownPlayers>0 && BossHealth[0]>=countdownHealth && (BossHealth[MAXBOSSES]>=countdownHealth || !Enabled3) && countdownTime>1 && !executed2)
 	{
 		if(countdownPlayers < 1)
@@ -11263,7 +11263,7 @@ public Action Timer_DrawGame(Handle timer)
 		return Plugin_Stop;
 	}
 
-	float alivePlayers = Enabled3 ? float(MercAlivePlayers + BossAlivePlayers - 2) : float(MercAlivePlayers);
+	float alivePlayers = Enabled3 ? float(MercAlivePlayers + BossAlivePlayers - 1) : float(MercAlivePlayers);
 	if(countdownPlayers < 1)
 	{
 		if(alivePlayers/playing > countdownPlayers)
@@ -17079,7 +17079,7 @@ void SetClientGlow(int client, float time1, float time2=-1.0)
 			GlowTimer[client]=0.0;
 			SetEntProp(client, Prop_Send, "m_bGlowEnabled", 0);
 		}
-		else if(GetRoundState() == 1)
+		else if(CheckRoundState() == 1)
 		{
 			SetEntProp(client, Prop_Send, "m_bGlowEnabled", 1);
 		}

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -15899,7 +15899,7 @@ public Action Timer_DisplayCharsetVote(Handle timer)
 	int total, charsets;
 	int shuffle = GetConVarInt(cvarShuffleCharset);
 	if(!shuffle)
-		AddMenuItem(menu, "0", "Random");*/
+		AddMenuItem(menu, "0", "Random");
 
 	do
 	{

--- a/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
@@ -39,7 +39,7 @@
 
 #define MAJOR_REVISION	"0"
 #define MINOR_REVISION	"5"
-#define STABLE_REVISION	"1"
+#define STABLE_REVISION	"2"
 #define PLUGIN_VERSION MAJOR_REVISION..."."...MINOR_REVISION..."."...STABLE_REVISION
 
 #define PROJECTILE	"model_projectile_replace"
@@ -524,7 +524,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 			char classname[PLATFORM_MAX_PATH], model[PLATFORM_MAX_PATH];
 			FF2_GetArgS(boss, this_plugin_name, OBJECTS, "classname", 1, classname, PLATFORM_MAX_PATH);
 			FF2_GetArgS(boss, this_plugin_name, OBJECTS, "model", 2, model, PLATFORM_MAX_PATH);
-			SpawnManyObjects(classname, client, model, FF2_GetArgI(boss, this_plugin_name, OBJECTS, "skin", 3), FF2_GetArgI(boss, this_plugin_name, OBJECTS, "count", 4, 14), FF2_GetArgF(boss, this_plugin_name, OBJECTS, "distance", 5, 30.0));
+			SpawnManyObjects(classname, client, model, FF2_GetArgI(boss, this_plugin_name, OBJECTS, "skin", 3), FF2_GetArgI(boss, this_plugin_name, OBJECTS, "amount", 4, 14), FF2_GetArgF(boss, this_plugin_name, OBJECTS, "distance", 5, 30.0));
 		}
 		if(FF2_HasAbility(boss, this_plugin_name, "special_dissolve"))
 		{
@@ -578,7 +578,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 					}
 				}
 
-				if(FF2_GetArgI(boss, this_plugin_name, "special_dropprop", "noragdoll", 3))
+				if(FF2_GetArgI(boss, this_plugin_name, "special_dropprop", "remove ragdolls", 3))
 					CreateTimer(0.01, Timer_RemoveRagdoll, GetEventInt(event, "userid"), TIMER_FLAG_NO_MAPCHANGE);
 
 				int prop = CreateEntityByName("prop_physics_override");
@@ -594,7 +594,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 					GetEntPropVector(client, Prop_Send, "m_vecOrigin", position);
 					position[2] += 20;
 					TeleportEntity(prop, position, NULL_VECTOR, NULL_VECTOR);
-					float duration = FF2_GetArgF(boss, this_plugin_name, "special_dropprop", "lifetime", 2);
+					float duration = FF2_GetArgF(boss, this_plugin_name, "special_dropprop", "duration", 2);
 					if(duration > 0.5)
 						CreateTimer(duration, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
 				}
@@ -613,7 +613,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 			SpawnManyObjects(classname, client, model, FF2_GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "skin", 3), FF2_GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "count", 4, 14), FF2_GetArgF(boss, this_plugin_name, OBJECTS_DEATH, "distance", 5, 30.0));
 		}
 
-		if(FF2_HasAbility(boss, this_plugin_name, "rage_cloneattack") && FF2_GetArgI(boss, this_plugin_name, "rage_cloneattack", "slay_on_boss_death", 12, 1) && !(GetEventInt(event, "death_flags") & TF_DEATHFLAG_DEADRINGER))
+		if(FF2_HasAbility(boss, this_plugin_name, "rage_cloneattack") && FF2_GetArgI(boss, this_plugin_name, "rage_cloneattack", "die on boss death", 12, 1) && !(GetEventInt(event, "death_flags") & TF_DEATHFLAG_DEADRINGER))
 		{
 			for(int target=1; target<=MaxClients; target++)
 			{
@@ -645,8 +645,8 @@ public Action Timer_Disable_Anims(Handle timer)
 	{
 		if(FF2_HasAbility(boss, this_plugin_name, "special_noanims"))
 		{
-			SetEntProp(client, Prop_Send, "m_bUseClassAnimations", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "animation", 2));
-			SetEntProp(client, Prop_Send, "m_bCustomModelRotates", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "rotate", 1));
+			SetEntProp(client, Prop_Send, "m_bUseClassAnimations", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "custom model animation", 2));
+			SetEntProp(client, Prop_Send, "m_bCustomModelRotates", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "custom model rotates", 1));
 		}
 	}
 	return Plugin_Continue;
@@ -745,7 +745,7 @@ public Action Timer_RemoveRagdoll(Handle timer, any userid)
 void Rage_Overlay(int boss, const char[] ability_name)
 {
 	char overlay[PLATFORM_MAX_PATH];
-	FF2_GetArgS(boss, this_plugin_name, ability_name, "overlay", 1, overlay, PLATFORM_MAX_PATH);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "path", 1, overlay, PLATFORM_MAX_PATH);
 	float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 2, 6.0);
 	TFTeam bossTeam = TF2_GetClientTeam(GetClientOfUserId(FF2_GetBossUserId(boss)));
 
@@ -810,7 +810,7 @@ int Rage_New_Weapon(int boss, const char[] ability_name)
 	FF2_GetArgS(boss, this_plugin_name, ability_name, "classname", 1, classname, sizeof(classname));
 	FF2_GetArgS(boss, this_plugin_name, ability_name, "attributes", 3, attributes, sizeof(attributes));
 
-	TF2_RemoveWeaponSlot(client, FF2_GetArgI(boss, this_plugin_name, ability_name, "weapon_slot", 4));
+	TF2_RemoveWeaponSlot(client, FF2_GetArgI(boss, this_plugin_name, ability_name, "weapon slot", 4));
 
 	int index = FF2_GetArgI(boss, this_plugin_name, ability_name, "index", 2);
 	int weapon = FF2_SpawnWeapon(client, classname, index, FF2_GetArgI(boss, this_plugin_name, ability_name, "level", 8), FF2_GetArgI(boss, this_plugin_name, ability_name, "quality", 9), attributes);
@@ -831,7 +831,7 @@ int Rage_New_Weapon(int boss, const char[] ability_name)
 		SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 1, _, 3);
 	}
 
-	if(FF2_GetArgI(boss, this_plugin_name, ability_name, "switch", 6))
+	if(FF2_GetArgI(boss, this_plugin_name, ability_name, "force switch", 6))
 		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 
 	int ammo = FF2_GetArgI(boss, this_plugin_name, ability_name, "ammo", 5);
@@ -1219,10 +1219,10 @@ int DissolveRagdoll(int ragdoll)
 void Rage_Clone(const char[] ability_name, int boss)
 {
 	Handle bossKV[8];
-	char bossName[32];
+	char bossName[64];
 	int client = GetClientOfUserId(FF2_GetBossUserId(boss));
-	bool changeModel = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, ability_name, "usemodel", 1));
-	int weaponMode = FF2_GetArgI(boss, this_plugin_name, ability_name, "weaponmode", 2);
+	bool changeModel = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, ability_name, "custom model", 1));
+	int weaponMode = FF2_GetArgI(boss, this_plugin_name, ability_name, "weapon mode", 2);
 	char model[PLATFORM_MAX_PATH];
 	FF2_GetArgS(boss, this_plugin_name, ability_name, "model", 3, model, sizeof(model));
 	int class = FF2_GetArgI(boss, this_plugin_name, ability_name, "class", 4);
@@ -1239,8 +1239,6 @@ void Rage_Clone(const char[] ability_name, int boss)
 
 	float position[3], velocity[3];
 	GetEntPropVector(GetClientOfUserId(FF2_GetBossUserId(boss)), Prop_Data, "m_vecOrigin", position);
-
-	FF2_GetBossName(boss, bossName, sizeof(bossName));
 
 	int maxKV;
 	for(maxKV=0; maxKV<8; maxKV++)
@@ -1353,6 +1351,7 @@ void Rage_Clone(const char[] ability_name, int boss)
 		velocity[2] = GetRandomFloat(300.0, 500.0);
 		TeleportEntity(clone, position, NULL_VECTOR, velocity);
 
+		FF2_GetBossName(boss, bossName, sizeof(bossName), 0, clone);
 		PrintHintText(clone, "%t", "seeldier_rage_message", bossName);
 
 		SetEntProp(clone, Prop_Data, "m_takedamage", 0);
@@ -1688,7 +1687,7 @@ void Rage_Bow(int boss)
 	int level = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "level", 7, 101);
 	int quality = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "quality", 8, 5);
 	int weapon = FF2_SpawnWeapon(client, classname, index, level, quality, attributes);
-	if(FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "switch", 9, 1))
+	if(FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "force switch", 9, 1))
 		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 
 	TFTeam team = (TF2_GetClientTeam(client)==TFTeam_Blue ? TFTeam_Red : TFTeam_Blue);
@@ -1812,16 +1811,23 @@ public Action Timer_Rage_Explosive_Dance(Handle timer, any boss)
 
 void Rage_Slowmo(int boss, const char[] ability_name)
 {
-	FF2_SetFF2flags(boss, FF2_GetFF2flags(boss)|FF2FLAG_CHANGECVAR);
-	SetConVarFloat(cvarTimeScale, FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1));
 	float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 1.0)+1.0;
-	SlowMoTimer = CreateTimer(duration*FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_StopSlowMo, boss, TIMER_FLAG_NO_MAPCHANGE);
+	if(duration <= 0)
+		return;
+
+	float timescale = FF2_GetArgF(boss, this_plugin_name, ability_name, "timescale", 2, 0.1);
+	if(timescale <= 0)
+		return;
+
+	FF2_SetFF2flags(boss, FF2_GetFF2flags(boss)|FF2FLAG_CHANGECVAR);
+	SetConVarFloat(cvarTimeScale, timescale);
+	SlowMoTimer = CreateTimer(duration*timescale, Timer_StopSlowMo, boss, TIMER_FLAG_NO_MAPCHANGE);
 	int client = GetClientOfUserId(FF2_GetBossUserId(boss));
 	FF2Flags[client] = FF2Flags[client]|FLAG_SLOWMOREADYCHANGE|FLAG_ONSLOWMO;
 	UpdateClientCheatValue(1);
 
 	if(client)
-		CreateTimer(duration*FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_RemoveEntity, EntIndexToEntRef(AttachParticle(client, GetClientTeam(client)==view_as<int>(TFTeam_Blue) ? "scout_dodge_blue" : "scout_dodge_red", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
+		CreateTimer(duration*timescale, Timer_RemoveEntity, EntIndexToEntRef(AttachParticle(client, GetClientTeam(client)==view_as<int>(TFTeam_Blue) ? "scout_dodge_blue" : "scout_dodge_red", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
 
 	EmitSoundToAll(SOUND_SLOW_MO_START, _, _, _, _, _, _, _, _, _, false);
 	EmitSoundToAll(SOUND_SLOW_MO_START, _, _, _, _, _, _, _, _, _, false);

--- a/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
@@ -39,7 +39,7 @@
 
 #define MAJOR_REVISION	"0"
 #define MINOR_REVISION	"5"
-#define STABLE_REVISION	"0"
+#define STABLE_REVISION	"1"
 #define PLUGIN_VERSION MAJOR_REVISION..."."...MINOR_REVISION..."."...STABLE_REVISION
 
 #define PROJECTILE	"model_projectile_replace"
@@ -105,9 +105,6 @@ bool smac = false;
 #endif
 bool HasSlowdown = false;
 
-//	Uber Rage
-float UberRageCount[MAXPLAYERS+1];
-
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	OnHaleRage = CreateGlobalForward("VSH_OnDoRage", ET_Hook, Param_FloatByRef);
@@ -133,7 +130,6 @@ public void OnPluginStart2()
 	if(version[0]!=1 || version[1]<19)
 		SetFailState("This subplugin depends on at least Unofficial FF2 v1.19.0");
 
-	HookEvent("object_deflected", OnDeflect, EventHookMode_Pre);
 	HookEvent("teamplay_round_start", OnRoundStart);
 	HookEvent("teamplay_round_win", OnRoundEnd);
 	HookEvent("player_death", OnPlayerDeath);
@@ -230,7 +226,7 @@ bool IsSlowMoActive()
 public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ability_name, int status)
 {
 	int client = GetClientOfUserId(FF2_GetBossUserId(boss));
-	int slot = GetArgI(boss, this_plugin_name, ability_name, "slot", 0);
+	int slot = FF2_GetArgI(boss, this_plugin_name, ability_name, "slot", 0);
 
 	if(!slot)  //Rage
 	{
@@ -265,7 +261,7 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 	}
 	else if(!strcmp(ability_name, "rage_uber"))
 	{
-		float duration = GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 5.0);
+		float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 5.0);
 		if(duration <= 0)
 			return Plugin_Continue;
 
@@ -275,7 +271,7 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 	}
 	else if(!strcmp(ability_name, "rage_stun"))
 	{
-		float delay = GetArgF(boss, this_plugin_name, ability_name, "delay", 10, 0.0);
+		float delay = FF2_GetArgF(boss, this_plugin_name, ability_name, "delay", 10, 0.0);
 		if(delay > 0)
 		{
 			CreateTimer(delay, Timer_Rage_Stun, boss);
@@ -295,12 +291,12 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 		bool otherTeamIsAlive;
 		char flagOverrideStr[12], particleEffect[48];
 
-		Tstun = GetArgF(boss, this_plugin_name, ability_name, "stun", 1, 2.0);
-		//bool friendly = view_as<bool>(GetArgI(boss, this_plugin_name, ability_name, "friendly", 2, 1));
-		GetArgS(boss, this_plugin_name, ability_name, "flags", 3, flagOverrideStr, sizeof(flagOverrideStr));
-		Tslowdown = GetArgF(boss, this_plugin_name, ability_name, "slowdown", 4, 0.0);
-		bool sounds = view_as<bool>(GetArgI(boss, this_plugin_name, ability_name, "sound", 5, 1));
-		GetArgS(boss, this_plugin_name, ability_name, "particle", 6, particleEffect, sizeof(particleEffect));
+		Tstun = FF2_GetArgF(boss, this_plugin_name, ability_name, "stun", 1, 2.0);
+		//bool friendly = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, ability_name, "friendly", 2, 1));
+		FF2_GetArgS(boss, this_plugin_name, ability_name, "flags", 3, flagOverrideStr, sizeof(flagOverrideStr));
+		Tslowdown = FF2_GetArgF(boss, this_plugin_name, ability_name, "slowdown", 4, 0.0);
+		bool sounds = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, ability_name, "sound", 5, 1));
+		FF2_GetArgS(boss, this_plugin_name, ability_name, "particle", 6, particleEffect, sizeof(particleEffect));
 
 		TflagOverride = ReadHexOrDecInt(flagOverrideStr);
 		if(TflagOverride == 0)
@@ -394,7 +390,7 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 		if(status<1 || Charged[client]>GetGameTime())
 			return Plugin_Continue;
 
-		float delay = GetArgF(boss, this_plugin_name, ability_name, "delay", 3);
+		float delay = FF2_GetArgF(boss, this_plugin_name, ability_name, "delay", 3);
 		if(!delay)
 		{
 			Timer_DemoCharge(INVALID_HANDLE, boss);
@@ -413,7 +409,6 @@ public Action OnRoundStart(Handle event, const char[] name, bool dontBroadcast)
 	int boss;
 	for(int client; client<MaxClients; client++)
 	{
-		UberRageCount[client] = 0.0;
 		FF2Flags[client] = 0;
 		CloneOwnerIndex[client] = -1;
 		#if defined _smac_included
@@ -447,7 +442,6 @@ public Action OnRoundEnd(Handle event, const char[] name, bool dontBroadcast)
 	if(SlowMoTimer)
 	{
 		TriggerTimer(SlowMoTimer);
-		KillTimer(SlowMoTimer);
 		SlowMoTimer = INVALID_HANDLE;
 	}
 
@@ -528,9 +522,9 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 		if(FF2_HasAbility(boss, this_plugin_name, OBJECTS))
 		{
 			char classname[PLATFORM_MAX_PATH], model[PLATFORM_MAX_PATH];
-			GetArgS(boss, this_plugin_name, OBJECTS, "classname", 1, classname, PLATFORM_MAX_PATH);
-			GetArgS(boss, this_plugin_name, OBJECTS, "model", 2, model, PLATFORM_MAX_PATH);
-			SpawnManyObjects(classname, client, model, GetArgI(boss, this_plugin_name, OBJECTS, "skin", 3), GetArgI(boss, this_plugin_name, OBJECTS, "count", 4, 14), GetArgF(boss, this_plugin_name, OBJECTS, "distance", 5, 30.0));
+			FF2_GetArgS(boss, this_plugin_name, OBJECTS, "classname", 1, classname, PLATFORM_MAX_PATH);
+			FF2_GetArgS(boss, this_plugin_name, OBJECTS, "model", 2, model, PLATFORM_MAX_PATH);
+			SpawnManyObjects(classname, client, model, FF2_GetArgI(boss, this_plugin_name, OBJECTS, "skin", 3), FF2_GetArgI(boss, this_plugin_name, OBJECTS, "count", 4, 14), FF2_GetArgF(boss, this_plugin_name, OBJECTS, "distance", 5, 30.0));
 		}
 		if(FF2_HasAbility(boss, this_plugin_name, "special_dissolve"))
 		{
@@ -542,7 +536,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 			{
 				TF2_RemoveWeaponSlot(attacker, TFWeaponSlot_Melee);
 				char attributes[128];
-				if(!GetArgS(boss, this_plugin_name, "special_cbs_multimelee", "attributes", 1, attributes, sizeof(attributes)))
+				if(!FF2_GetArgS(boss, this_plugin_name, "special_cbs_multimelee", "attributes", 1, attributes, sizeof(attributes)))
 					strcopy(attributes, sizeof(attributes), "68 ; 2 ; 2 ; 3.1 ; 275 ; 1");
 
 				int weapon;
@@ -567,7 +561,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 		if(FF2_HasAbility(boss, this_plugin_name, "special_dropprop"))
 		{
 			char model[PLATFORM_MAX_PATH];
-			if(GetArgS(boss, this_plugin_name, "special_dropprop", "model", 1, model, PLATFORM_MAX_PATH))
+			if(FF2_GetArgS(boss, this_plugin_name, "special_dropprop", "model", 1, model, PLATFORM_MAX_PATH))
 			{
 				if(!IsModelPrecached(model))	// Make sure the boss author precached the model (similar to above)
 				{
@@ -584,7 +578,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 					}
 				}
 
-				if(GetArgI(boss, this_plugin_name, "special_dropprop", "noragdoll", 3))
+				if(FF2_GetArgI(boss, this_plugin_name, "special_dropprop", "noragdoll", 3))
 					CreateTimer(0.01, Timer_RemoveRagdoll, GetEventInt(event, "userid"), TIMER_FLAG_NO_MAPCHANGE);
 
 				int prop = CreateEntityByName("prop_physics_override");
@@ -600,7 +594,7 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 					GetEntPropVector(client, Prop_Send, "m_vecOrigin", position);
 					position[2] += 20;
 					TeleportEntity(prop, position, NULL_VECTOR, NULL_VECTOR);
-					float duration = GetArgF(boss, this_plugin_name, "special_dropprop", "lifetime", 2);
+					float duration = FF2_GetArgF(boss, this_plugin_name, "special_dropprop", "lifetime", 2);
 					if(duration > 0.5)
 						CreateTimer(duration, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
 				}
@@ -614,12 +608,12 @@ public int OnPlayerDeath(Handle event, const char[] name, bool dontBroadcast)
 		if(FF2_HasAbility(boss, this_plugin_name, OBJECTS_DEATH))
 		{
 			char classname[PLATFORM_MAX_PATH], model[PLATFORM_MAX_PATH];
-			GetArgS(boss, this_plugin_name, OBJECTS_DEATH, "classname", 1, classname, PLATFORM_MAX_PATH);
-			GetArgS(boss, this_plugin_name, OBJECTS_DEATH, "model", 2, model, PLATFORM_MAX_PATH);
-			SpawnManyObjects(classname, client, model, GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "skin", 3), GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "count", 4, 14), GetArgF(boss, this_plugin_name, OBJECTS_DEATH, "distance", 5, 30.0));
+			FF2_GetArgS(boss, this_plugin_name, OBJECTS_DEATH, "classname", 1, classname, PLATFORM_MAX_PATH);
+			FF2_GetArgS(boss, this_plugin_name, OBJECTS_DEATH, "model", 2, model, PLATFORM_MAX_PATH);
+			SpawnManyObjects(classname, client, model, FF2_GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "skin", 3), FF2_GetArgI(boss, this_plugin_name, OBJECTS_DEATH, "count", 4, 14), FF2_GetArgF(boss, this_plugin_name, OBJECTS_DEATH, "distance", 5, 30.0));
 		}
 
-		if(FF2_HasAbility(boss, this_plugin_name, "rage_cloneattack") && GetArgI(boss, this_plugin_name, "rage_cloneattack", "slay_on_boss_death", 12, 1) && !(GetEventInt(event, "death_flags") & TF_DEATHFLAG_DEADRINGER))
+		if(FF2_HasAbility(boss, this_plugin_name, "rage_cloneattack") && FF2_GetArgI(boss, this_plugin_name, "rage_cloneattack", "slay_on_boss_death", 12, 1) && !(GetEventInt(event, "death_flags") & TF_DEATHFLAG_DEADRINGER))
 		{
 			for(int target=1; target<=MaxClients; target++)
 			{
@@ -651,8 +645,8 @@ public Action Timer_Disable_Anims(Handle timer)
 	{
 		if(FF2_HasAbility(boss, this_plugin_name, "special_noanims"))
 		{
-			SetEntProp(client, Prop_Send, "m_bUseClassAnimations", GetArgI(boss, this_plugin_name, "special_noanims", "animation", 2));
-			SetEntProp(client, Prop_Send, "m_bCustomModelRotates", GetArgI(boss, this_plugin_name, "special_noanims", "rotate", 1));
+			SetEntProp(client, Prop_Send, "m_bUseClassAnimations", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "animation", 2));
+			SetEntProp(client, Prop_Send, "m_bCustomModelRotates", FF2_GetArgI(boss, this_plugin_name, "special_noanims", "rotate", 1));
 		}
 	}
 	return Plugin_Continue;
@@ -676,11 +670,11 @@ public void OnProjectileSpawned(int entity)
 		if(boss>=0 && FF2_HasAbility(boss, this_plugin_name, PROJECTILE))
 		{
 			char projectile[PLATFORM_MAX_PATH], classname[PLATFORM_MAX_PATH];
-			GetArgS(boss, this_plugin_name, PROJECTILE, "projectile", 1, projectile, PLATFORM_MAX_PATH);
+			FF2_GetArgS(boss, this_plugin_name, PROJECTILE, "projectile", 1, projectile, PLATFORM_MAX_PATH);
 			GetEntityClassname(entity, classname, sizeof(classname));
 			if(StrEqual(classname, projectile, false))
 			{
-				GetArgS(boss, this_plugin_name, PROJECTILE, "model", 2, classname, PLATFORM_MAX_PATH);
+				FF2_GetArgS(boss, this_plugin_name, PROJECTILE, "model", 2, classname, PLATFORM_MAX_PATH);
 				if(IsModelPrecached(classname))
 				{
 					SetEntityModel(entity, classname);
@@ -751,8 +745,8 @@ public Action Timer_RemoveRagdoll(Handle timer, any userid)
 void Rage_Overlay(int boss, const char[] ability_name)
 {
 	char overlay[PLATFORM_MAX_PATH];
-	GetArgS(boss, this_plugin_name, ability_name, "overlay", 1, overlay, PLATFORM_MAX_PATH);
-	float duration = GetArgF(boss, this_plugin_name, ability_name, "duration", 2, 6.0);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "overlay", 1, overlay, PLATFORM_MAX_PATH);
+	float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 2, 6.0);
 	TFTeam bossTeam = TF2_GetClientTeam(GetClientOfUserId(FF2_GetBossUserId(boss)));
 
 	Format(overlay, PLATFORM_MAX_PATH, "r_screenoverlay \"%s\"", overlay);
@@ -786,7 +780,7 @@ public Action Timer_Remove_Overlay(Handle timer, TFTeam bossTeam)
 
 public Action Timer_DemoCharge(Handle timer, int boss)
 {
-	float duration = GetArgF(boss, this_plugin_name, "special_democharge", "duration", 1, 0.25);
+	float duration = FF2_GetArgF(boss, this_plugin_name, "special_democharge", "duration", 1, 0.25);
 	if(duration<0 && duration!=TFCondDuration_Infinite)
 		return Plugin_Continue;
 
@@ -795,11 +789,11 @@ public Action Timer_DemoCharge(Handle timer, int boss)
 	TF2_AddCondition(client, TFCond_Charging, duration);
 
 	float charge = FF2_GetBossCharge(boss, 0);
-	if(charge>GetArgF(boss, this_plugin_name, "special_democharge", "minimum", 5, 10.0) &&
-	   charge<GetArgF(boss, this_plugin_name, "special_democharge", "maximum", 6, 90.0))
-		FF2_SetBossCharge(boss, 0, charge-GetArgF(boss, this_plugin_name, "special_democharge", "rage", 4, 0.4));
+	if(charge>FF2_GetArgF(boss, this_plugin_name, "special_democharge", "minimum", 5, 10.0) &&
+	   charge<FF2_GetArgF(boss, this_plugin_name, "special_democharge", "maximum", 6, 90.0))
+		FF2_SetBossCharge(boss, 0, charge-FF2_GetArgF(boss, this_plugin_name, "special_democharge", "rage", 4, 0.4));
 
-	Charged[client] = GetGameTime()+GetArgF(boss, this_plugin_name, "special_democharge", "cooldown", 2);
+	Charged[client] = GetGameTime()+FF2_GetArgF(boss, this_plugin_name, "special_democharge", "cooldown", 2);
 	return Plugin_Continue;
 }
 
@@ -813,13 +807,13 @@ int Rage_New_Weapon(int boss, const char[] ability_name)
 		return;
 
 	char classname[64], attributes[256];
-	GetArgS(boss, this_plugin_name, ability_name, "classname", 1, classname, sizeof(classname));
-	GetArgS(boss, this_plugin_name, ability_name, "attributes", 3, attributes, sizeof(attributes));
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "classname", 1, classname, sizeof(classname));
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "attributes", 3, attributes, sizeof(attributes));
 
-	TF2_RemoveWeaponSlot(client, GetArgI(boss, this_plugin_name, ability_name, "weapon_slot", 4));
+	TF2_RemoveWeaponSlot(client, FF2_GetArgI(boss, this_plugin_name, ability_name, "weapon_slot", 4));
 
-	int index = GetArgI(boss, this_plugin_name, ability_name, "index", 2);
-	int weapon = FF2_SpawnWeapon(client, classname, index, GetArgI(boss, this_plugin_name, ability_name, "level", 8), GetArgI(boss, this_plugin_name, ability_name, "quality", 9), attributes);
+	int index = FF2_GetArgI(boss, this_plugin_name, ability_name, "index", 2);
+	int weapon = FF2_SpawnWeapon(client, classname, index, FF2_GetArgI(boss, this_plugin_name, ability_name, "level", 8), FF2_GetArgI(boss, this_plugin_name, ability_name, "quality", 9), attributes);
 	if(StrEqual(classname, "tf_weapon_builder") && index!=735)  //PDA, normal sapper
 	{
 		SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 1, _, 0);
@@ -837,11 +831,11 @@ int Rage_New_Weapon(int boss, const char[] ability_name)
 		SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 1, _, 3);
 	}
 
-	if(GetArgI(boss, this_plugin_name, ability_name, "switch", 6))
+	if(FF2_GetArgI(boss, this_plugin_name, ability_name, "switch", 6))
 		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 
-	int ammo = GetArgI(boss, this_plugin_name, ability_name, "ammo", 5);
-	int clip = GetArgI(boss, this_plugin_name, ability_name, "clip", 7);
+	int ammo = FF2_GetArgI(boss, this_plugin_name, ability_name, "ammo", 5);
+	int clip = FF2_GetArgI(boss, this_plugin_name, ability_name, "clip", 7);
 	if(ammo || clip)
 		FF2_SetAmmo(client, weapon, ammo, clip);
 }
@@ -856,45 +850,45 @@ public Action Timer_Rage_Stun(Handle timer, any boss)
 	float bossPosition[3], targetPosition[3];
 	GetEntPropVector(client, Prop_Send, "m_vecOrigin", bossPosition);
  // Initial Duration
-	float duration = GetArgF(boss, this_plugin_name, "rage_stun", "duration", 1, 5.0);
+	float duration = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "duration", 1, 5.0);
  // Distance
-	float distance = GetArgF(boss, this_plugin_name, "rage_stun", "distance", 2, -1.0);
+	float distance = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "distance", 2, -1.0);
 	if(distance <= 0)
 		distance = FF2_GetRageDist(boss, this_plugin_name, "rage_stun");
  // Stun Flags
 	char flagOverrideStr[12];
-	GetArgS(boss, this_plugin_name, "rage_stun", "flags", 3, flagOverrideStr, sizeof(flagOverrideStr));
+	FF2_GetArgS(boss, this_plugin_name, "rage_stun", "flags", 3, flagOverrideStr, sizeof(flagOverrideStr));
 	int flagOverride = ReadHexOrDecInt(flagOverrideStr);
 	if(!flagOverride)
 		flagOverride = TF_STUNFLAGS_GHOSTSCARE|TF_STUNFLAG_NOSOUNDOREFFECT;
  // Slowdown
-	float slowdown = GetArgF(boss, this_plugin_name, "rage_stun", "slowdown", 4);
+	float slowdown = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "slowdown", 4);
  // Sound To Boss
-	bool sounds = view_as<bool>(GetArgI(boss, this_plugin_name, "rage_stun", "sound", 5, 1));
+	bool sounds = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, "rage_stun", "sound", 5, 1));
  // Particle Effect
 	char particleEffect[48];
-	GetArgS(boss, this_plugin_name, "rage_stun", "particle", 6, particleEffect, sizeof(particleEffect));
+	FF2_GetArgS(boss, this_plugin_name, "rage_stun", "particle", 6, particleEffect, sizeof(particleEffect));
 	if(!strlen(particleEffect))
 		particleEffect = SPOOK;
  // Ignore
-	int ignore = GetArgI(boss, this_plugin_name, "rage_stun", "uber", 7, 0);
+	int ignore = FF2_GetArgI(boss, this_plugin_name, "rage_stun", "uber", 7, 0);
  // Friendly Fire
-	int friendly = GetArgI(boss, this_plugin_name, "rage_stun", "friendly", 8, -1);
+	int friendly = FF2_GetArgI(boss, this_plugin_name, "rage_stun", "friendly", 8, -1);
 	if(friendly < 0)
 		friendly = GetConVarInt(FindConVar("mp_friendlyfire"));
  // Remove Parachute
-	bool removeBaseJumperOnStun = view_as<bool>(GetArgI(boss, this_plugin_name, "rage_stun", "basejumper", 9, GetConVarInt(cvarBaseJumperStun)));
+	bool removeBaseJumperOnStun = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, "rage_stun", "basejumper", 9, GetConVarInt(cvarBaseJumperStun)));
  // Max Duration
-	float maxduration = GetArgF(boss, this_plugin_name, "rage_stun", "max", 11, -1.0);
+	float maxduration = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "max", 11, -1.0);
  // Add Duration
-	float addduration = GetArgF(boss, this_plugin_name, "rage_stun", "add", 12, 0.0);
+	float addduration = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "add", 12, 0.0);
 	if(maxduration <= 0)
 	{
 		maxduration = duration;
 		addduration = 0.0;
 	}
  // Solo Rage Duration
-	float soloduration = GetArgF(boss, this_plugin_name, "rage_stun", "solo", 13, -1.0);
+	float soloduration = FF2_GetArgF(boss, this_plugin_name, "rage_stun", "solo", 13, -1.0);
 	if(soloduration <= 0)
 		soloduration = duration;
 
@@ -1026,17 +1020,6 @@ public Action Timer_StopUber(Handle timer, any boss)
 	return Plugin_Continue;
 }
 
-public Action OnDeflect(Handle event, const char[] name, bool dontBroadcast)
-{
-	int boss = FF2_GetBossIndex(GetClientOfUserId(GetEventInt(event, "userid")));
-	if(boss != -1)
-	{
-		if(UberRageCount[boss] > 11)
-			UberRageCount[boss] -= 10;
-	}
-	return Plugin_Continue;
-}
-
 
 /*	Building Stun	*/
 
@@ -1047,27 +1030,27 @@ void Rage_StunBuilding(const char[] ability_name, int boss)
 	GetEntPropVector(GetClientOfUserId(FF2_GetBossUserId(boss)), Prop_Send, "m_vecOrigin", bossPosition);
 
  // Duration
-	float duration = GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 7.0);
+	float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 7.0);
  // Distance
-	float distance = GetArgF(boss, this_plugin_name, ability_name, "distance", 2, -1.0);
+	float distance = FF2_GetArgF(boss, this_plugin_name, ability_name, "distance", 2, -1.0);
 	if(distance <= 0)
 		distance = FF2_GetRageDist(boss, this_plugin_name, ability_name);
  // Building Health
  	bool destory = false;
-	float health = GetArgF(boss, this_plugin_name, ability_name, "health", 3, 1.0);
+	float health = FF2_GetArgF(boss, this_plugin_name, ability_name, "health", 3, 1.0);
 	if(health <= 0)
 		destory = true;
  // Sentry Ammo
-	float ammo = GetArgF(boss, this_plugin_name, ability_name, "ammo", 4, 1.0);
+	float ammo = FF2_GetArgF(boss, this_plugin_name, ability_name, "ammo", 4, 1.0);
  // Sentry Rockets
-	float rockets = GetArgF(boss, this_plugin_name, ability_name, "rocket", 5, 1.0);
+	float rockets = FF2_GetArgF(boss, this_plugin_name, ability_name, "rocket", 5, 1.0);
  // Particle Effect
 	char particleEffect[48];
-	GetArgS(boss, this_plugin_name, ability_name, "particle", 6, particleEffect, sizeof(particleEffect));
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "particle", 6, particleEffect, sizeof(particleEffect));
 	if(!strlen(particleEffect))
 		particleEffect = SPOOK;
  // Buildings
-	int buildings = GetArgI(boss, this_plugin_name, ability_name, "building", 7, 1);
+	int buildings = FF2_GetArgI(boss, this_plugin_name, ability_name, "building", 7, 1);
 	// 1: Sentry
 	// 2: Dispenser
 	// 3: Teleporter
@@ -1076,7 +1059,7 @@ void Rage_StunBuilding(const char[] ability_name, int boss)
 	// 6: Dispenser + Teleporter
 	// 7: ALL
  // Friendly Fire
-	int friendly = GetArgI(boss, this_plugin_name, ability_name, "friendly", 8, -1);
+	int friendly = FF2_GetArgI(boss, this_plugin_name, ability_name, "friendly", 8, -1);
 	if(friendly < 0)
 		friendly = GetConVarInt(FindConVar("mp_friendlyfire"));
 
@@ -1238,21 +1221,21 @@ void Rage_Clone(const char[] ability_name, int boss)
 	Handle bossKV[8];
 	char bossName[32];
 	int client = GetClientOfUserId(FF2_GetBossUserId(boss));
-	bool changeModel = view_as<bool>(GetArgI(boss, this_plugin_name, ability_name, "usemodel", 1));
-	int weaponMode = GetArgI(boss, this_plugin_name, ability_name, "weaponmode", 2);
+	bool changeModel = view_as<bool>(FF2_GetArgI(boss, this_plugin_name, ability_name, "usemodel", 1));
+	int weaponMode = FF2_GetArgI(boss, this_plugin_name, ability_name, "weaponmode", 2);
 	char model[PLATFORM_MAX_PATH];
-	GetArgS(boss, this_plugin_name, ability_name, "model", 3, model, sizeof(model));
-	int class = GetArgI(boss, this_plugin_name, ability_name, "class", 4);
-	float ratio = GetArgF(boss, this_plugin_name, ability_name, "ratio", 5);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "model", 3, model, sizeof(model));
+	int class = FF2_GetArgI(boss, this_plugin_name, ability_name, "class", 4);
+	float ratio = FF2_GetArgF(boss, this_plugin_name, ability_name, "ratio", 5);
 	char classname[64] = "tf_weapon_bottle";
-	GetArgS(boss, this_plugin_name, ability_name, "classname", 6, classname, sizeof(classname));
-	int index = GetArgI(boss, this_plugin_name, ability_name, "index", 7, 191);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "classname", 6, classname, sizeof(classname));
+	int index = FF2_GetArgI(boss, this_plugin_name, ability_name, "index", 7, 191);
 	char attributes[128] = "68 ; -1";
-	GetArgS(boss, this_plugin_name, ability_name, "attributes", 8, attributes, sizeof(attributes));
-	int ammo = GetArgI(boss, this_plugin_name, ability_name, "ammo", 9, -1);
-	int clip = GetArgI(boss, this_plugin_name, ability_name, "clip", 10, -1);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "attributes", 8, attributes, sizeof(attributes));
+	int ammo = FF2_GetArgI(boss, this_plugin_name, ability_name, "ammo", 9, -1);
+	int clip = FF2_GetArgI(boss, this_plugin_name, ability_name, "clip", 10, -1);
 	char healthformula[768];
-	GetArgS(boss, this_plugin_name, ability_name, "health", 11, healthformula, sizeof(healthformula));
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "health", 11, healthformula, sizeof(healthformula));
 
 	float position[3], velocity[3];
 	GetEntPropVector(GetClientOfUserId(FF2_GetBossUserId(boss)), Prop_Data, "m_vecOrigin", position);
@@ -1681,7 +1664,7 @@ void Rage_Bow(int boss)
 	TF2_RemoveWeaponSlot(client, TFWeaponSlot_Primary);
 	char attributes[64], classname[64];
 
-	GetArgS(boss, this_plugin_name, "rage_cbs_bowrage", "attributes", 1, attributes, sizeof(attributes));
+	FF2_GetArgS(boss, this_plugin_name, "rage_cbs_bowrage", "attributes", 1, attributes, sizeof(attributes));
 	if(!strlen(attributes))
 	{
 		if(GetConVarBool(cvarStrangeWep))
@@ -1694,18 +1677,18 @@ void Rage_Bow(int boss)
 		}
 	}
 
-	int maximum = GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "max", 2, 9);
-	float ammo = GetArgF(boss, this_plugin_name, "rage_cbs_bowrage", "ammo", 3, 1.0);
-	int clip = GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "clip", 4, 1);
-	GetArgS(boss, this_plugin_name, "rage_cbs_bowrage", "classname", 5, classname, sizeof(classname));
+	int maximum = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "max", 2, 9);
+	float ammo = FF2_GetArgF(boss, this_plugin_name, "rage_cbs_bowrage", "ammo", 3, 1.0);
+	int clip = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "clip", 4, 1);
+	FF2_GetArgS(boss, this_plugin_name, "rage_cbs_bowrage", "classname", 5, classname, sizeof(classname));
 	if(!strlen(classname))
 		classname="tf_weapon_compound_bow";
 
-	int index = GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "index", 6, 1005);
-	int level = GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "level", 7, 101);
-	int quality = GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "quality", 8, 5);
+	int index = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "index", 6, 1005);
+	int level = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "level", 7, 101);
+	int quality = FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "quality", 8, 5);
 	int weapon = FF2_SpawnWeapon(client, classname, index, level, quality, attributes);
-	if(GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "switch", 9, 1))
+	if(FF2_GetArgI(boss, this_plugin_name, "rage_cbs_bowrage", "switch", 9, 1))
 		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
 
 	TFTeam team = (TF2_GetClientTeam(client)==TFTeam_Blue ? TFTeam_Red : TFTeam_Blue);
@@ -1745,20 +1728,20 @@ public Action Timer_Prepare_Explosion_Rage(Handle timer, Handle data)
 	char ability_name[64];
 	ReadPackString(data, ability_name, sizeof(ability_name));
 
-	ExpCount[client] = GetArgI(boss, this_plugin_name, ability_name, "count", 3, 35);
-	ExpDamage[client] = GetArgF(boss, this_plugin_name, ability_name, "damage", 4, 180.0);
-	ExpRange[client] = GetArgI(boss, this_plugin_name, ability_name, "distance", 4, 350);
+	ExpCount[client] = FF2_GetArgI(boss, this_plugin_name, ability_name, "count", 3, 35);
+	ExpDamage[client] = FF2_GetArgF(boss, this_plugin_name, ability_name, "damage", 4, 180.0);
+	ExpRange[client] = FF2_GetArgI(boss, this_plugin_name, ability_name, "distance", 5, 350);
 
-	if(GetArgI(boss, this_plugin_name, ability_name, "taunt", 5, 1))
+	if(FF2_GetArgI(boss, this_plugin_name, ability_name, "taunt", 6, 1))
 		ClientCommand(client, "+taunt");
 
-	CreateTimer(GetArgF(boss, this_plugin_name, ability_name, "delay", 2, 0.12), Timer_Rage_Explosive_Dance, boss, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
+	CreateTimer(FF2_GetArgF(boss, this_plugin_name, ability_name, "delay", 2, 0.12), Timer_Rage_Explosive_Dance, boss, TIMER_REPEAT|TIMER_FLAG_NO_MAPCHANGE);
 
 	float position[3];
 	GetEntPropVector(client, Prop_Data, "m_vecOrigin", position);
 
 	char sound[PLATFORM_MAX_PATH];
-	GetArgS(boss, this_plugin_name, ability_name, "sound", 1, sound, PLATFORM_MAX_PATH);
+	FF2_GetArgS(boss, this_plugin_name, ability_name, "sound", 1, sound, PLATFORM_MAX_PATH);
 	if(strlen(sound))
 	{
 		FF2_EmitVoiceToAll(sound, client, _, _, _, _, _, client, position);
@@ -1830,15 +1813,15 @@ public Action Timer_Rage_Explosive_Dance(Handle timer, any boss)
 void Rage_Slowmo(int boss, const char[] ability_name)
 {
 	FF2_SetFF2flags(boss, FF2_GetFF2flags(boss)|FF2FLAG_CHANGECVAR);
-	SetConVarFloat(cvarTimeScale, GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1));
-	float duration = GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 1.0)+1.0;
-	SlowMoTimer = CreateTimer(duration*GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_StopSlowMo, boss, TIMER_FLAG_NO_MAPCHANGE);
+	SetConVarFloat(cvarTimeScale, FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1));
+	float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 1.0)+1.0;
+	SlowMoTimer = CreateTimer(duration*FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_StopSlowMo, boss, TIMER_FLAG_NO_MAPCHANGE);
 	int client = GetClientOfUserId(FF2_GetBossUserId(boss));
 	FF2Flags[client] = FF2Flags[client]|FLAG_SLOWMOREADYCHANGE|FLAG_ONSLOWMO;
 	UpdateClientCheatValue(1);
 
 	if(client)
-		CreateTimer(duration*GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_RemoveEntity, EntIndexToEntRef(AttachParticle(client, GetClientTeam(client)==view_as<int>(TFTeam_Blue) ? "scout_dodge_blue" : "scout_dodge_red", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
+		CreateTimer(duration*FF2_GetArgF(boss, this_plugin_name, ability_name, "time", 2, 0.1), Timer_RemoveEntity, EntIndexToEntRef(AttachParticle(client, GetClientTeam(client)==view_as<int>(TFTeam_Blue) ? "scout_dodge_blue" : "scout_dodge_red", 75.0)), TIMER_FLAG_NO_MAPCHANGE);
 
 	EmitSoundToAll(SOUND_SLOW_MO_START, _, _, _, _, _, _, _, _, _, false);
 	EmitSoundToAll(SOUND_SLOW_MO_START, _, _, _, _, _, _, _, _, _, false);
@@ -1870,7 +1853,7 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float veloc
 	if(buttons & IN_ATTACK)
 	{
 		FF2Flags[client]&=~FLAG_SLOWMOREADYCHANGE;
-		CreateTimer(GetArgF(boss, this_plugin_name, "rage_matrix_attack", "delay", 3, 0.2), Timer_SlowMoChange, boss, TIMER_FLAG_NO_MAPCHANGE);
+		CreateTimer(FF2_GetArgF(boss, this_plugin_name, "rage_matrix_attack", "delay", 3, 0.2), Timer_SlowMoChange, boss, TIMER_FLAG_NO_MAPCHANGE);
 
 		float bossPosition[3], endPosition[3], eyeAngles[3];
 		GetEntPropVector(client, Prop_Send, "m_vecOrigin", bossPosition);

--- a/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ffbat_defaults.sp
@@ -251,15 +251,15 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
     /*
        Rages
     */
-	if(!strcmp(ability_name, "rage_new_weapon"))
+	if(!StrContains(ability_name, "rage_new_weapon"))
 	{
 		Rage_New_Weapon(boss, ability_name);
 	}
-	else if(!strcmp(ability_name, "rage_overlay"))
+	else if(!StrContains(ability_name, "rage_overlay"))
 	{
 		Rage_Overlay(boss, ability_name);
 	}
-	else if(!strcmp(ability_name, "rage_uber"))
+	else if(!StrContains(ability_name, "rage_uber"))
 	{
 		float duration = FF2_GetArgF(boss, this_plugin_name, ability_name, "duration", 1, 5.0);
 		if(duration <= 0)
@@ -269,7 +269,7 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 		SetEntProp(client, Prop_Data, "m_takedamage", 0);
 		CreateTimer(duration, Timer_StopUber, boss, TIMER_FLAG_NO_MAPCHANGE);
 	}
-	else if(!strcmp(ability_name, "rage_stun"))
+	else if(StrEqual(ability_name, "rage_stun"))
 	{
 		float delay = FF2_GetArgF(boss, this_plugin_name, ability_name, "delay", 10, 0.0);
 		if(delay > 0)
@@ -281,11 +281,11 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 			Timer_Rage_Stun(INVALID_HANDLE, boss);
 		}
 	}
-	else if(!strcmp(ability_name, "rage_stunsg"))
+	else if(!StrContains(ability_name, "rage_stunsg"))
 	{
 		Rage_StunBuilding(ability_name, boss);
 	}
-	else if(!strcmp(ability_name, "rage_instant_teleport"))
+	else if(!StrContains(ability_name, "rage_instant_teleport"))
 	{
 		float position[3];
 		bool otherTeamIsAlive;
@@ -356,20 +356,20 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 			TeleportEntity(client, position, NULL_VECTOR, NULL_VECTOR);
 		}
 	}
-	else if(!strcmp(ability_name, "rage_cloneattack"))
+	else if(!StrContains(ability_name, "rage_cloneattack"))
 	{
 		Rage_Clone(ability_name, boss);
 	}
-	else if(!strcmp(ability_name, "rage_tradespam"))
+	else if(!StrContains(ability_name, "rage_tradespam"))
 	{
 		CreateTimer(0.0, Timer_Demopan_Rage, 1, TIMER_FLAG_NO_MAPCHANGE);
 		Demopan = GetClientTeam(client);
 	}
-	else if(!strcmp(ability_name, "rage_cbs_bowrage"))
+	else if(StrEqual(ability_name, "rage_cbs_bowrage"))
 	{
 		Rage_Bow(boss);
 	}
-	else if(!strcmp(ability_name, "rage_explosive_dance"))
+	else if(StrEqual(ability_name, "rage_explosive_dance"))
 	{
 		SetEntityMoveType(GetClientOfUserId(FF2_GetBossUserId(boss)), MOVETYPE_NONE);
 		Handle data;
@@ -378,14 +378,14 @@ public Action FF2_OnAbility2(int boss, const char[] plugin_name, const char[] ab
 		WritePackString(data, ability_name);
 		ResetPack(data);
 	}
-	else if(!strcmp(ability_name, "rage_matrix_attack"))
+	else if(!StrContains(ability_name, "rage_matrix_attack"))
 	{
 		Rage_Slowmo(boss, ability_name);
 	}
     /*
        Specials
     */
-	else if(!strcmp(ability_name, "special_democharge"))
+	else if(StrEqual(ability_name, "special_democharge"))
 	{
 		if(status<1 || Charged[client]>GetGameTime())
 			return Plugin_Continue;
@@ -813,7 +813,7 @@ int Rage_New_Weapon(int boss, const char[] ability_name)
 	TF2_RemoveWeaponSlot(client, FF2_GetArgI(boss, this_plugin_name, ability_name, "weapon slot", 4));
 
 	int index = FF2_GetArgI(boss, this_plugin_name, ability_name, "index", 2);
-	int weapon = FF2_SpawnWeapon(client, classname, index, FF2_GetArgI(boss, this_plugin_name, ability_name, "level", 8), FF2_GetArgI(boss, this_plugin_name, ability_name, "quality", 9), attributes);
+	int weapon = FF2_SpawnWeapon(client, classname, index, FF2_GetArgI(boss, this_plugin_name, ability_name, "level", 8, 101), FF2_GetArgI(boss, this_plugin_name, ability_name, "quality", 9, 5), attributes);
 	if(StrEqual(classname, "tf_weapon_builder") && index!=735)  //PDA, normal sapper
 	{
 		SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 1, _, 0);

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -865,6 +865,32 @@ stock void FReplyToCommand(int client, const char[] message, any ...)
 stock int FF2_SpawnWeapon(int client, char[] name, int index, int level, int qual, char[] att, bool visible=true)
 {
 	#if defined _tf2items_included
+	if(StrEqual(name, "saxxy", false))	// if "saxxy" is specified as the name, replace with appropiate name
+	{ 
+		switch(TF2_GetPlayerClass(client))
+		{
+			case TFClass_Scout:	ReplaceString(name, 64, "saxxy", "tf_weapon_bat", false);
+			case TFClass_Soldier:	ReplaceString(name, 64, "saxxy", "tf_weapon_shovel", false);
+			case TFClass_Pyro:	ReplaceString(name, 64, "saxxy", "tf_weapon_fireaxe", false);
+			case TFClass_DemoMan:	ReplaceString(name, 64, "saxxy", "tf_weapon_bottle", false);
+			case TFClass_Heavy:	ReplaceString(name, 64, "saxxy", "tf_weapon_fists", false);
+			case TFClass_Engineer:	ReplaceString(name, 64, "saxxy", "tf_weapon_wrench", false);
+			case TFClass_Medic:	ReplaceString(name, 64, "saxxy", "tf_weapon_bonesaw", false);
+			case TFClass_Sniper:	ReplaceString(name, 64, "saxxy", "tf_weapon_club", false);
+			case TFClass_Spy:	ReplaceString(name, 64, "saxxy", "tf_weapon_knife", false);
+		}
+	}
+	else if(StrEqual(name, "tf_weapon_shotgun", false))	// If using tf_weapon_shotgun for Soldier/Pyro/Heavy/Engineer
+	{
+		switch(TF2_GetPlayerClass(client))
+		{
+			case TFClass_Soldier:	ReplaceString(name, 64, "tf_weapon_shotgun", "tf_weapon_shotgun_soldier", false);
+			case TFClass_Pyro:	ReplaceString(name, 64, "tf_weapon_shotgun", "tf_weapon_shotgun_pyro", false);
+			case TFClass_Heavy:	ReplaceString(name, 64, "tf_weapon_shotgun", "tf_weapon_shotgun_hwg", false);
+			case TFClass_Engineer:	ReplaceString(name, 64, "tf_weapon_shotgun", "tf_weapon_shotgun_primary", false);
+		}
+	}
+
 	Handle hWeapon = TF2Items_CreateItem(OVERRIDE_ALL|FORCE_GENERATION);
 	if(hWeapon == INVALID_HANDLE)
 		return -1;
@@ -903,9 +929,18 @@ stock int FF2_SpawnWeapon(int client, char[] name, int index, int level, int qua
 	}
 
 	int entity = TF2Items_GiveNamedItem(client, hWeapon);
-	CloseHandle(hWeapon);
+	delete hWeapon;
 	EquipPlayerWeapon(client, entity);
-	SetEntProp(entity, Prop_Send, "m_bValidatedAttachedEntity", visible);
+
+	if(visible)
+	{
+		SetEntProp(entity, Prop_Send, "m_bValidatedAttachedEntity", 1);
+	}
+	else
+	{
+		SetEntProp(entity, Prop_Send, "m_iWorldModelIndex", -1);
+		SetEntPropFloat(entity, Prop_Send, "m_flModelScale", 0.001);
+	}
 	return entity;
 	#else
 	return -1;

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -924,7 +924,7 @@ stock int FF2_SpawnWeapon(int client, char[] name, int index, int level, int qua
  *
  * @return         	The value of the argument or default value
  */
-stock int GetArgI(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, int defValue=0)
+stock int FF2_GetArgI(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, int defValue=0)
 {
 	return FF2_NamedArgumentsUsed(boss, plugin_name, ability_name) ?
 	       FF2_GetArgNamedI(boss, plugin_name, ability_name, argument, FF2_GetAbilityArgument(boss, plugin_name, ability_name, index, defValue)) :
@@ -943,7 +943,7 @@ stock int GetArgI(int boss, const char[] plugin_name, const char[] ability_name,
  *
  * @return         	The value of the argument or default value
  */
-stock float GetArgF(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, float defValue=0.0)
+stock float FF2_GetArgF(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, float defValue=0.0)
 {
 	return FF2_NamedArgumentsUsed(boss, plugin_name, ability_name) ?
 	       FF2_GetArgNamedF(boss, plugin_name, ability_name, argument, FF2_GetAbilityArgumentFloat(boss, plugin_name, ability_name, index, defValue)) :
@@ -963,7 +963,7 @@ stock float GetArgF(int boss, const char[] plugin_name, const char[] ability_nam
  *
  * @return         	Number of characters stored in the provided buffer
  */
-stock int GetArgS(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, char[] buffer, int bufferLength)
+stock int FF2_GetArgS(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, int index, char[] buffer, int bufferLength)
 {
 	if(FF2_NamedArgumentsUsed(boss, plugin_name, ability_name))
 	{

--- a/addons/sourcemod/translations/freak_fortress_2.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2.phrases.txt
@@ -130,53 +130,53 @@
 		"en"		"It's {blue}super{default} effective..."
 		"ru"		"Это {blue}супер{default} эффективно..."
 	}
-	"help_scout"	// Menu
+	"help_scout"	// Deprecated
 	{
 		"en"		"Baby Face's Blaster drains boost.\nStock pistol always mini-crit.\nAll bleed damage is crit-boosted.\nCandy Cane drops a health pack on hit.\nFan O' War gives a slight speed boost, faster fire rate,\nbut lower damage and disables double jump."
 		"ru"		"Обрез малыша ускоряет.\nПистолет даёт мини-криты.\nКровоточащий урон критует.\nКарамельная трость выбивает аптечку.\nВеер Войны слегка ускоряет бег и скорострельность,\nно понижает урон и отменяет двойной прыжок."
 	}
-	"help_soldier"	// Menu
+	"help_soldier"	// Deprecated
 	{
 		"en"		"Airstrike gains a head on hit.\nBattalion's Backup heavily reduces damage to nearby players while active.\nBoth boots reduce fall damage but Mantreads create greater rocketjumps.\nPain Train acts like a Boston Basher."
 		"ru"		"Авиаудар считывает головы за удар.\nПоддержка батальона сильно снижает урон по ближайшим игрокам.\nОба предмета снижают урон от падения, а Людодавы улучшают ракетный прыжок.\nКостыль действует как Бостонский раздолбай."
 	}
-	"help_pyro"	// Menu
+	"help_pyro"	// Deprecated
 	{
 		"en"		"Airblasting causes the boss to build rage.\nThe Detonator has increased push force.\nGas Passer explodes the boss if hit.\nHomewrecker and Maul applies more knockback.\nThird Degree gives Uber on hit to the medic healing you.\nNeon Annihilator slows shortly on hit.\nSharpened Volcano Fragment removes your flamethrower."
 		"ru"		"Отталкивание босса заполняет ему шкалу ярости.\nУ Детонатора увеличена толкающая сила.\nЗапасной бак подрывает босса при ударе.\nКрушитель и Молот сильнее отбрасывают.\nТретья степень даёт Убер при ударе по лечащему вас медику.\nНеоновый аннигилятор ненадолго замедляет при ударе.\nЗаострённый осколок вулкана удаляет огнемёт."
 	}
-	"help_demo"	// Menu
+	"help_demo"	// Deprecated
 	{
 		"en"		"All shields block one hit from the Boss.\nChargin' Targe gives faster melee swing.\nEyelander and reskins gain heads on hit.\nUllapool Caber explosion has increased damage.\nPain Train acts like a Boston Basher."
 		"ru"		"Все щиты блокируют 1 удар босса.\nШтурмовой щит ускоряет размах рукопашного оружия.\nОдноглазый горец и рескины считывают головы при ударе.\nУ взрыва Аллапульского бревна увеличен урон.\nКостыль действует как Бостонский раздолбай."
 	}
-	"help_heavy"	// Menu
+	"help_heavy"	// Deprecated
 	{
 		"en"		"Natascha gives faster movement speed while deployed.\nHuo-Long Heater fires flares instead of bullets.\nK.G.B. makes you a melee tank.\nGloves of Running Urently gives massive speed but decays HP.\nEviction Notice gives a passive speed boost.\nHoliday Punch gives you faster weapon switch."
 		"ru"		"Наташа ускоряет передвижение при раскрутке.\nОгненный дракон стреляет огнём вместо пуль.\nК.Г.Б. превращают тебя в рукопашного танка.\nГ.Р.У. сильно ускоряют, но отнимают ОЗ.\nУведомление о выселении даёт пассивное ускорение.\nПраздничный удар ускоряет смену оружия."
 	}
-	"help_eggineer"	// Menu
+	"help_eggineer"	// Deprecated
 	{
 		"en"		"Frontier Justice gains crits while your sentry is attacking.\nWrangler slows you down while deployed.\nPomson 6000 and Short Circuit slows on hit.\nEureka Effect has bi-teleporters but can't self-teleport."
 		"ru"		"Самосуд даёт криты, если турель видит босса.\nПоводырь замедляет бег при использовании.\nПомсон 6000 и Короткое замыкание замедляют при ударе.\nОзарение имеет би-телепорты, но нельзя телепортировать себя."
 	}
-	"help_medic"	// Menu
+	"help_medic"	// Deprecated
 	{
 		"en"		"Medi Guns give Uber, Crits, and no knockback on use.\nCan overheal to twice the max HP.\nSyringe Gun and Crossbow give ubercharge on hit."
 		"ru"		"Лечебные пушки дают Убер, криты, и имуннитет к отбрасыванию.\nСверхлечение дважды увеличивает ОЗ от макс.\nШприцемёт и Арбалет дают убер-заряд при ударе."
 	}
-	"help_sniper"	// Menu
+	"help_sniper"	// Deprecated
 	{
 		"en"		"Stock sniper rifles causes the boss to glow based on charge.\nJarate throws a bomb instead.\nRazorback blocks a hit from the boss.\nDarwin's Danger Shield gives you +85 HP.\nCozy Camper gives you a modified SMG.\nAll melees can wall climb at the cost of 15 HP."
 		"ru"		"Обычные винтовки подсвечивают босса, основываясь на заряд.\nВместо Банкате бросается бомба.\nБронепанцирь блокирует 1 удар босса.\nДарвинистский щит даёт +85 ОЗ.\nНабор для кемпинга даёт ППМ.\nРукопашное оружие позволяет лазить по стенам, но стоит 15 ОЗ."
 		// Remove wall climb if your not using it
 	}
-	"help_spie"	// Menu
+	"help_spie"	// Deprecated
 	{
 		"en"		"All revolvers minicrit while not disguised.\nBut Enforcer deals crits while disguised.\nEnforcer, Ambassador, and Diamondback crits deal more damage.\nBackstabs does about 10%% of the boss's max HP.\nYour Eternal Reward/Wanga Prick backstabs disguise you instantly and silently.\nKunai backstabs will give you a health bonus.\nBig Earner gives you full cloak and speed on backstab."
 		"ru"		"Все револьверы мини-критуют вне маскировки.\nНо Принудитель критует в маскировке.\nКриты Принудителя, Амбассадора, и Алмазного змея усилены.\nУдары в спину сносят ~10%% от макс. ОЗ босса.\nУдар в спину Вечным Покоем/Иголкой Вуду замаскирует тебя.\nУдар в спину Кунаем даёт прирост ОЗ.\nУдар в спину Главным Дельцом даёт полный запас часов и скорость."
 	}
-	"help_melee"	// Menu
+	"help_melee"	// Deprecated
 	{
 		"en"		"Most of melee weapons (except the Spy knives) deal critical hits.\nUse /ff2 menu to disable this notifications."
 		"ru"		"Многие рукопашные оружия (кроме ножей шпионов) наносят криты.\nДанное уведомление отключается в меню /ff2."

--- a/addons/sourcemod/translations/freak_fortress_2_weaps.phrases.txt
+++ b/addons/sourcemod/translations/freak_fortress_2_weaps.phrases.txt
@@ -1,0 +1,618 @@
+"Phrases"
+{
+	// Required Translations (Default Translations)
+	"info_title"
+	{
+		"en"		"Use /ff2infotoggle to disable these notifications."
+	}
+	"primary_scout"
+	{
+		"en"		""
+	}
+	"primary_soldier"
+	{
+		"en"		""
+	}
+	"primary_pyro"
+	{
+		"en"		"Airblast causes the boss to build 8%% rage"
+	}
+	"primary_demo"
+	{
+		"en"		""
+	}
+	"primary_heavy"
+	{
+		"en"		""
+	}
+	"primary_engineer"
+	{
+		"en"		""
+	}
+	"primary_medic"
+	{
+		"en"		"Syringe Guns gains 5%% Ubercharge for every hit."
+	}
+	"primary_sniper"
+	{
+		"en"		"Sniper Rifles causes the boss to glow based on charge time."
+	}
+	"primary_spy"
+	{
+		"en"		"Revolvers are mini-crit boosted."
+	}
+	"primary_merc"
+	{
+		"en"		""
+	}
+	"secondary_scout"
+	{
+		"en"		"Stock Pistols are mini-crit boosted."
+	}
+	"secondary_soldier"
+	{
+		"en"		""
+	}
+	"secondary_pyro"
+	{
+		"en"		""
+	}
+	"secondary_demo"
+	{
+		"en"		""
+	}
+	"secondary_heavy"
+	{
+		"en"		""
+	}
+	"secondary_engineer"
+	{
+		"en"		""
+	}
+	"secondary_medic"
+	{
+		"en"		"Medi-Guns can overheal twice as much, slightly faster Ubercharge rate,\nfaster switch speed, and gives crits and self-overheal on Ubercharge."
+	}
+	"secondary_sniper"
+	{
+		"en"		"SMGs are mini-crit boosted."
+	}
+	"secondary_spy"
+	{
+		"en"		"Sappers can be used to stun some bosses."
+	}
+	"secondary_merc"
+	{
+		"en"		""
+	}
+	"melee_scout"
+	{
+		"en"		"Bats (except the Sandman) are always crit boosted."
+	}
+	"melee_soldier"
+	{
+		"en"		"Shovels (except the Market Garnder) are always crit boosted."
+	}
+	"melee_pyro"
+	{
+		"en"		"Fire Axes are always crit boosted."
+	}
+	"melee_demo"
+	{
+		"en"		"Bottles are always crit boosted."
+	}
+	"melee_heavy"
+	{
+		"en"		"Fists (except the Holiday Punch) are always crit boosted."
+	}
+	"melee_engineer"
+	{
+		"en"		"Wrenches are always crit boosted."
+	}
+	"melee_medic"
+	{
+		"en"		"Bonesaws are always crit boosted."
+	}
+	"melee_sniper"
+	{
+		"en"		"Kukris are always crit boosted."
+	}
+	"melee_spy"
+	{
+		"en"		"Knives deal a high amount of damage upon backstabbing a boss."
+	}
+	"melee_merc"
+	{
+		"en"		""
+	}
+	"pda_engineer"
+	{
+		"en"		"Sentries you own are destoryed upon dieing."
+	}
+	"pda_spy"
+	{
+		"en"		"\nDisguise Kit allows you to look like a boss or minion."
+	}
+
+	// Optional Translations (Weapon Indexes)
+	"primary_772"
+	{
+		"en"		"Baby Face's Blaster loses boost over time."
+	}
+	"primary_127"
+	{
+		"en"		"The Direct Hit causes a critical hit upon hitting mid-air targets."
+	}
+	"primary_237"
+	{
+		"en"		"Rocket Jumper causes little damage and gives no extra reserve ammo."
+	}
+	"primary_414"
+	{
+		"en"		"The Liberty Launcher deals slightly less damage."
+	}
+	"primary_441"
+	{
+		"en"		"The Cow Mangler 5000 has increased afterburn damage."
+	}
+	"primary_730"
+	{
+		"en"		"The Beggar's Bazooka has increased reserve ammo."
+	}
+	"primary_1104"
+	{
+		"en"		"The Air Strike gains heads with damage dealt against the boss."
+	}
+	"primary_40"
+	{
+		"en"		"The Backburner's airblast requires less ammo but causes the boss to build 8%% rage."
+	}
+	"primary_594"
+	{
+		"en"		"The Phlogistinator gives damage reduction during 'Mmmph'."
+	}
+	"primary_1146"
+	{
+		"en"		"The Backburner's airblast requires less ammo but causes the boss to build 8%% rage."
+	}
+	"primary_405"
+	{
+		"en"		"Ali Baba's Wee Booties doesn't need a shield for extra movement speed."
+	}
+	"primary_405"
+	{
+		"en"		"The Bootlegger doesn't need a shield for extra movement speed."
+	}
+	"primary_41"
+	{
+		"en"		"Natascha doesn't have slow on hit but gives faster movement speed while deployed."
+	}
+	"primary_312"
+	{
+		"en"		"The Brass Beast has increased melee vulnerability while active."
+	}
+	"primary_811"
+	{
+		"en"		"The Huo-Long Heater has increased afterburn damage."
+	}
+	"primary_832"
+	{
+		"en"		"The Huo-Long Heater has increased afterburn damage."
+	}
+	"primary_141"
+	{
+		"en"		"The Frontier Justice is crit boosted while your sentry is attacking."
+	}
+	"primary_588"
+	{
+		"en"		"The Pomson 6000 is always crit boosted and slows on hit."
+	}
+	"primary_1004"
+	{
+		"en"		"The Frontier Justice is crit boosted while your sentry is attacking."
+	}
+	"primary_305"
+	{
+		"en"		"Crusader's Crossbow is always crit boosted and gains 20%% Ubercharge on hit."
+	}
+	"primary_1079"
+	{
+		"en"		"Crusader's Crossbow is always crit boosted and gains 20%% Ubercharge on hit."
+	}
+	"primary_56"
+	{
+		"en"		"The Huntsman is always crit boosted, deals extra damage, and has increased reserve ammo."
+	}
+	"primary_230"
+	{
+		"en"		"The Sydney Sleeper deals less damage while the boss has less than 90%% rage."
+	}
+	"primary_402"
+	{
+		"en"		"The Bazaar Bargain removes deployed movement speed penalty and gives faster weapon switch"
+	}
+	"primary_526"
+	{
+		"en"		""	// Machina
+	}
+	"primary_752"
+	{
+		"en"		"The Hitman's Heatmaker allows gaining Focus while using Focus."
+	}
+	"primary_1005"
+	{
+		"en"		"The Huntsman is always crit boosted, deals extra damage, and has increased reserve ammo."
+	}
+	"primary_1092"
+	{
+		"en"		"The Fortified Compound is always crit boosted, deals extra damage, and has increased reserve ammo."
+	}
+	"primary_30665"
+	{
+		"en"		""	// Shooting Star
+	}
+	"primary_61"
+	{
+		"en"		"The Ambassador deals extra damage on headshots."
+	}
+	"primary_224"
+	{
+		"en"		"L'Etranger has less cloak on hit."
+	}
+	"primary_460"
+	{
+		"en"		"The Enforcer is crit boosted while your disguised."
+	}
+	"primary_525"
+	{
+		"en"		"The Diamondback deals extra damage with Revenge crits and gains 3 Revenge crits upon backstabbing the boss."
+	}
+	"primary_1006"
+	{
+		"en"		"The Ambassador deals extra damage on headshots."
+	}
+	"secondary_46"
+	{
+		"en"		""
+	}
+	"secondary_163"
+	{
+		"en"		"Crit-a-Cola gives criticals during the effect."
+	}
+	"secondary_222"
+	{
+		"en"		""
+	}
+	"secondary_449"
+	{
+		"en"		""
+	}
+	"secondary_773"
+	{
+		"en"		""
+	}
+	"secondary_812"
+	{
+		"en"		"The Flying Guillotine is always crit boosted."
+	}
+	"secondary_833"
+	{
+		"en"		"The Flying Guillotine is always crit boosted."
+	}
+	"secondary_1121"
+	{
+		"en"		""
+	}
+	"secondary_1145"
+	{
+		"en"		""
+	}
+	"secondary_129"
+	{
+		"en"		"The Buff Banner's rage lasts longer."
+	}
+	"secondary_133"
+	{
+		"en"		"Gunboats gives resistance to fall damage."
+	}
+	"secondary_226"
+	{
+		"en"		"The Battalion's Backup rage gives increased damage resistance."
+	}
+	"secondary_442"
+	{
+		"en"		"The Righteous Bison is always crit boosted and slows on hit."
+	}
+	"secondary_444"
+	{
+		"en"		"The Mantreads gives higher blast jump height and resistance to fall damage."
+	}
+	"secondary_1001"
+	{
+		"en"		"The Buff Banner's rage lasts longer."
+	}
+	"secondary_39"
+	{
+		"en"		"The Flare Gun attacks faster."
+	}
+	"secondary_351"
+	{
+		"en"		"The Detonator has massive self push force but less ammo and no mini-crits against burning players"
+	}
+	"secondary_595"
+	{
+		"en"		"The Manmelter attacks faster."
+	}
+	"secondary_740"
+	{
+		"en"		"The Scorch Shot has less ammo."
+	}
+	"secondary_1081"
+	{
+		"en"		"The Flare Gun attacks faster."
+	}
+	"secondary_1179"
+	{
+		"en"		"Thermal Thruster is able to re-launch mid-air."
+	}
+	"secondary_1180"
+	{
+		"en"		"Gas Passer explodes ignited enemies but requires more damage for recharge."
+	}
+	"secondary_131"
+	{
+		"en"		"The Chargin' Targe gives slightly faster melee attack speed and blocks hits before breaking."
+	}
+	"secondary_265"
+	{
+		"en"		"Sticky Jumper causes little damage and gives no extra reserve ammo."
+	}
+	"secondary_406"
+	{
+		"en"		"The Splendid Screen has more impact damage, no faster recharge speed, and blocks hits before breaking."
+	}
+	"secondary_1099"
+	{
+		"en"		"The Tide Turner blocks hits before breaking."
+	}
+	"secondary_1144"
+	{
+		"en"		"The Chargin' Targe gives slightly faster melee attack speed and blocks hits before breaking."
+	}
+	"secondary_140"
+	{
+		"en"		"The Wrangler gives less movement speed and has increased melee vulnerability while active."
+	}
+	"secondary_528"
+	{
+		"en"		"The Short Circuit is always crit boosted and slows on hit."
+	}
+	"secondary_1086"
+	{
+		"en"		"The Wrangler gives less movement speed and has increased melee vulnerability while active."
+	}
+	"secondary_30668"
+	{
+		"en"		"The Gigar Counter gives less movement speed and has increased melee vulnerability while active."
+	}
+	"secondary_35"
+	{
+		"en"		"The Kritzkrieg can overheal twice as much, faster Ubercharge rate,\nfaster switch speed, and longer Ubercharge."
+	}
+	"secondary_411"
+	{
+		"en"		"The Quick-Fix can fully overheal, faster Ubercharge rate,\nfaster switch speed, and provides crits on Ubercharge."
+	}
+	"secondary_998"
+	{
+		"en"		"The Vaccinator can overheal twice as much, slower Ubercharge rate, faster switch speed,\nno resistances, shorter Ubercharge, but gives crits on Ubercharge and a projectile shield meter."
+	}
+	"secondary_57"
+	{
+		"en"		"The Razorback blocks hits before breaking."
+	}
+	"secondary_58"
+	{
+		"en"		"Jarate drains 8%% rage on bosses but doesn't give mini-crits."
+	}
+	"secondary_231"
+	{
+		"en"		"Darwin's Danger Shield gives a massive health boost but less health from healers and health packs."
+	}
+	"secondary_642"
+	{
+		"en"		"Cozy Camper gives a modified SMG that bleeds on hit but deals less damage."
+	}
+	"secondary_751"
+	{
+		"en"		"The Cleaner's Carbine is crit boosted during rage."
+	}
+	"secondary_1083"
+	{
+		"en"		"Jarate drains 8%% rage on bosses but doesn't give mini-crits."
+	}
+	"secondary_1105"
+	{
+		"en"		"Jarate drains 8%% rage on bosses but doesn't give mini-crits."
+	}
+	"secondary_810"
+	{
+		"en"		"The Red-Tape Recorder can be used to Mark-For-Death some bosses."
+	}
+	"secondary_831"
+	{
+		"en"		"The Red-Tape Recorder can be used to Mark-For-Death some bosses."
+	}
+	"secondary_415"
+	{
+		"en"		"The Reserve Shooter has a smaller clip size but causes a critical hit upon hitting mid-air targets."
+	}
+	"melee_44"
+	{
+		"en"		"The Sandman doesn't receive a crit boost."
+	}
+	"melee_317"
+	{
+		"en"		"The Candy Cane drops a health kit upon hitting a boss but slightly less healing from Medics."
+	}
+	"melee_349"
+	{
+		"en"		"Sun-on-a-Stick deals more damage against enemies on fire."
+	}
+	"melee_355"
+	{
+		"en"		"The Fan O'War gives faster swing speed, movement speed, but less primary ammo and no double jumps."
+	}
+	"melee_128"
+	{
+		"en"		"The Equalizer has increased melee vulnerability while active."
+	}
+	"melee_154"
+	{
+		"en"		"The Pain Train bleeds on hit but causes to hit yourself if you miss. Idiot."
+	}
+	"melee_357"
+	{
+		"en"		"The Half-Zatoichi's Honorbound fades upon hitting a boss, consecutive hits give less health."
+	}
+	"melee_416"
+	{
+		"en"		"The Market Gardener is only crit boosted while your rocket jumping,\ngives slower attack speed, and hitting the boss while mid-air deals massive damage."
+	}
+	"melee_775"
+	{
+		"en"		"The Escape Plan has increased melee vulnerability while active."
+	}
+	"melee_153"
+	{
+		"en"		"Homewrecker deals more damage but attacks slower."
+	}
+	"melee_214"
+	{
+		"en"		"The Powerjack heals upon hitting the boss."
+	}
+	"melee_348"
+	{
+		"en"		"Sharpened Volcano Fragment removes your primary weapon, gives damage reduction while active,\nheals on hit and afterburn, faster movement speed, and slower switch speed."
+	}
+	"melee_466"
+	{
+		"en"		"The Maul deals more damage but attacks slower."
+	}
+	"melee_593"
+	{
+		"en"		"The Third Degree gives Ubercharge on hit to the Medic(s) currently healing you but slightly less healing from Medics."
+	}
+	"melee_813"
+	{
+		"en"		"Neon Annihilator slows on hit."
+	}
+	"melee_834"
+	{
+		"en"		"Neon Annihilator slows on hit."
+	}
+	"melee_1181"
+	{
+		"en"		"Hot Hand's speed boost lasts slightly longer."
+	}
+	"melee_132"
+	{
+		"en"		"The Eyelander gains a head upon hitting a boss."
+	}
+	"melee_266"
+	{
+		"en"		"Horseless Headless Horsemann's Headtaker gains a head upon hitting a boss."
+	}
+	"melee_307"
+	{
+		"en"		"Ullapool Caber deals more damage on explosion but loses crit boost afterwards."
+	}
+	"melee_327"
+	{
+		"en"		"The Claidheamh Mòr gains health and charge upon hitting a boss and gives slightly more damage vulnerability."
+	}
+	"melee_404"
+	{
+		"en"		"Gives more charge on hit, slower charge recharge, no ammo penalty, and slightly slower switch speed."
+	}
+	"melee_482"
+	{
+		"en"		"Nessie's Nine Iron gains a head upon hitting a boss."
+	}
+	"melee_1082"
+	{
+		"en"		"The Eyelander gains a head upon hitting a boss."
+	}
+	"melee_43"
+	{
+		"en"		"The Killing Gloves of Boxing removes your primary weapon, gives damage reduction while active,\nheals on hit, less healing, faster movement speed, and slower switch speed."
+	}
+	"melee_239"
+	{
+		"en"		"Gloves of Running Urgently gives increase movement speed but drains health instead of max health."
+	}
+	"melee_310"
+	{
+		"en"		"Warrior's Spirit heals upon hitting a boss."
+	}
+	"melee_331"
+	{
+		"en"		"Fists of Steel gives ranged and melee damage reduction while active."
+	}
+	"melee_426"
+	{
+		"en"		"The Eviction Notice gives passive increased movement speed, no max health drain, and maximum attack speed."
+	}
+	"melee_656"
+	{
+		"en"		"The Holiday Punch gives instant switch speed but doesn't receive a crit boost and unable to force joy."
+	}
+	"melee_1084"
+	{
+		"en"		"Gloves of Running Urgently gives increase movement speed but drains health instead of max health."
+	}
+	"melee_1100"
+	{
+		"en"		"The Bread Bite gives increase movement speed but drains health instead of max health."
+	}
+	"melee_155"
+	{
+		"en"		"The Southern Hospitality's fire vulnerability is effected by all damage types."
+	}
+	"melee_329"
+	{
+		"en"		"The Jag has slower repair speed and deals less damage."
+	}
+	"melee_589"
+	{
+		"en"		"The Eureka Effect building hit speed boost and metal from pickups is increased,\nteleporters are bi-directional, but unable to self teleport."
+	}
+	"melee_173"
+	{
+		"en"		"The Vita-Saw gains 15%% Ubercharge on hit and gains a short speed boost."
+	}
+	"melee_232"
+	{
+		"en"		"The Bushwacka increases wall climb force."
+	}
+	"melee_225"
+	{
+		"en"		"Your Eternal Reward disguises you upon backstabbing a boss and makes little noise."
+	}
+	"melee_356"
+	{
+		"en"		"Conniver's Kunai overheals upon backstabbing a boss."
+	}
+	"melee_461"
+	{
+		"en"		"The Big Earner gives a speed boost and full cloak upon backstabbing a boss."
+	}
+	"melee_574"
+	{
+		"en"		"The Wanga Prick disguises you upon backstabbing a boss and makes little noise."
+	}
+	"pda_60"
+	{
+		"en"		"The Cloak and Dagger recharges slower and drains based on time.\nDisguise Kit allows you to look like a boss or minion."
+	}
+}


### PR DESCRIPTION
- #64 Improved class info with showing stats of their current loadout
- #86 Shields when the type is set to 1 will block debuffs
- FF2_SpawnWeapon stock now accepts `saxxy`, and `tf_weapon_shotgun`
- Improved FF2_SpawnWeapon's hiding weapons
- (1.11.0) Renamed `GetArgI`, `GetArgF`, and `GetArgS` with `FF2_` prefix
- Removed ALT-FIRE and RELOAD HUD tips
- Fixed issues with selecting a companion boss
- Improved team balancing during Boss vs Boss rounds
- Fixed rival bosses counting as companions with queue points
- Fixed missing sound error anytime an annotation message appears
- `FF2FLAG_ALLOW_AMMO_PICKUPS` and `FF2FLAG_ALLOW_HEALTH_PICKUPS` can be removed from non-bosses
- Fixed outline, control point, timer starting too early in Boss vs Boss rounds
- Forced bosses to stay on their correct team during the round
- (1.11.0) Added buttonmodes 4 (Duck) and 5 (Scoreboard)
- (1.11.0) Added args for default_abilities charges
- Fixed snipers outlining the boss before the round starts