### PR TITLE
[Fix] Index Out-of-Bounds error related to BGM with lives

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5331,7 +5331,7 @@ public Action Timer_PrepareBGM(Handle timer, any userid)
 			KvGetString(BossKV[Special[0]], lives, lives, sizeof(lives));
 			if(StringToInt(lives))
 			{
-				if(StringToInt(lives) != BossLives[Special[0]])
+				if(StringToInt(lives) != BossLives[0])
 					continue;
 			}
 			break;
@@ -16577,11 +16577,11 @@ public Action Command_SkipSong(int client, int args)
 		KvGetString(BossKV[Special[0]], lives, lives, sizeof(lives));
 		if(lives[0])
 		{
-			if(StringToInt(lives) != BossLives[Special[0]])
+			if(StringToInt(lives) != BossLives[0])
 			{
 				for(int i; i<index-1; i++)
 				{
-					if(StringToInt(lives) != BossLives[Special[0]])
+					if(StringToInt(lives) != BossLives[0])
 					{
 						cursongId[client] = i;
 						continue;
@@ -16710,7 +16710,7 @@ public Action Command_Tracklist(int client, int args)
 			KvGetString(BossKV[Special[0]], lives, lives, sizeof(lives));
 			if(lives[0])
 			{
-				if(StringToInt(lives) != BossLives[Special[0]])
+				if(StringToInt(lives) != BossLives[0])
 					continue;
 			}
 			FormatEx(id3[0], sizeof(id3[]), "name%i", trackIdx);
@@ -16824,7 +16824,7 @@ public int Command_TrackListH(Menu menu, MenuAction action, int param1, int para
 					KvGetString(BossKV[Special[0]], lives, lives, sizeof(lives));
 					if(lives[0])
 					{
-						if(StringToInt(lives) != BossLives[Special[0]])
+						if(StringToInt(lives) != BossLives[0])
 						{
 							if(MusicTimer[param1] != INVALID_HANDLE)
 								KillTimer(MusicTimer[param1]);

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -5482,7 +5482,6 @@ void StartMusic(int client=0)
 		{
 			playBGM[target] = true;  //This includes the 0th index
 			if(IsValidClient(target))
-
 			{
 				CreateTimer(0.2, Timer_PrepareBGM, GetClientUserId(target), TIMER_FLAG_NO_MAPCHANGE);
 			}


### PR DESCRIPTION
There was a typo in the code related to BGM where it tries to get the Boss' remaining lives from the array `BossLives` using the `Special[boss]` instead of just `boss` (boss' index). This lead an "_Index Out-of-Bounds_" exception if the boss has any _"lifeX"_ parameter inside _"sound_bgm"_ in its _.cfg_ and if there is more than 36 bosses in _characters.cfg_.

If there is less than 36 bosses in that file, the code will play the wrong music without any error message.

Note: I didn't see this error in my last PR as I was testing my boss with just one boss in _characters.cfg_ (then, the `Special[boss]` value was the same as the boss' index in the round, i.e. `0`)