### PR TITLE
[Feature] Enhancing the system for blocking bosses in specific maps

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2221,9 +2221,9 @@ public void EnableFF2()
 	SetConVarString(FindConVar("mp_humans_must_join_team"), "any");
 
 	cvarTags = FindConVar("sv_tags");
-        MyAddServerTag("ff2");
-        MyAddServerTag("hale");
-        MyAddServerTag("vsh");
+	MyAddServerTag("ff2");
+	MyAddServerTag("hale");
+	MyAddServerTag("vsh");
 
 	float time = Announce;
 	if(time > 1.0)
@@ -2306,9 +2306,9 @@ public void DisableFF2()
 	SetConVarString(FindConVar("mp_humans_must_join_team"), mp_humans_must_join_team);
 	hostName.SetString(oldName);
 
-        MyRemoveServerTag("ff2");
-        MyRemoveServerTag("hale");
-        MyRemoveServerTag("vsh");
+	MyRemoveServerTag("ff2");
+	MyRemoveServerTag("hale");
+	MyRemoveServerTag("vsh");
 
 	if(doorCheckTimer != INVALID_HANDLE)
 	{
@@ -3947,7 +3947,7 @@ public void OnRoundSetup(Event event, const char[] name, bool dontBroadcast)
 				else
 				{
 					FPrintToChat(client, "%t", "FF2 Toggle Enabled Notification");
-   				}
+				}
 				continue;
 			}
 		}
@@ -13384,7 +13384,7 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 					case 307:  //Ullapool Caber
 					{
 						if(!GetEntProp(weapon, Prop_Send, "m_iDetonated") && allowedDetonations<4)	// If using ullapool caber, only trigger if bomb hasn't been detonated
-                        			{
+						{
 							if(TimesTen)
 							{
 								damage = ((Pow(float(BossHealthMax[boss]), 0.74074)-(Cabered[client]/128.0*float(BossHealthMax[boss])))/(3+(cvarTimesTen.FloatValue*allowedDetonations*3)))*bosses;
@@ -13568,7 +13568,7 @@ public Action OnTakeDamage(int client, int &attacker, int &inflictor, float &dam
 					{
 						if(RemoveCond(attacker, TFCond_BlastJumping) && cvarMarket.FloatValue)	// New way to check explosive jumping status
 						//if((FF2flags[attacker] & FF2FLAG_ROCKET_JUMPING) && cvarMarket.FloatValue)
-                        			{
+						{
 							if(TimesTen)
 							{
 								damage = ((Pow(float(BossHealthMax[boss]), 0.74074)-(Marketed[client]/128.0*float(BossHealthMax[boss])))/(cvarTimesTen.FloatValue*3))*bosses*cvarMarket.FloatValue;
@@ -16591,7 +16591,7 @@ public Action Command_SkipSong(int client, int args)
 		return Plugin_Handled;
 	}
 
-    	FReplyToCommand(client, "%t", "track_skipped");
+	FReplyToCommand(client, "%t", "track_skipped");
 
 	StopMusic(client, true);
 

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -6227,10 +6227,10 @@ public Action Command_SetMyBoss(int client, int args)
 		}
 		else if(MapBlocked[config])
 		{
-            if(cvarShowBossBlocked.BoolValue)
-            {
-                menu.AddItem(boss, bossName, ITEMDRAW_DISABLED);
-            }
+			if(cvarShowBossBlocked.BoolValue)
+			{
+				menu.AddItem(boss, bossName, ITEMDRAW_DISABLED);
+			}
 		}
 		else if(KvGetNum(BossKV[config], "nofirst") && (RoundCount<arenaRounds || (RoundCount==arenaRounds && CheckRoundState()!=1)))
 		{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -357,6 +357,7 @@ ConVar cvarRageDamage;
 ConVar cvarDifficulty;
 ConVar cvarEnableSandmanStun;
 ConVar cvarCacheDeletion;
+ConVar cvarShowBossBlocked;
 
 Handle FF2Cookies;
 Handle StatCookies;
@@ -1161,6 +1162,7 @@ public void OnPluginStart()
 	cvarDifficulty = CreateConVar("ff2_difficulty_random", "0.0", "0-Players can set their difficulty, #-Chance of difficulty", _, true, 0.0, true, 100.0);
 	cvarEnableSandmanStun = CreateConVar("ff2_enable_sandmanstun", "0", "0-Disable the Sandman stun ability, 1-Enable the Sandman stun ability", _, true, 0.0, true, 1.0);
 	cvarCacheDeletion = CreateConVar("ff2_cache_deletion_time", "0.0", "0.0-Every map change, any other value in minutes", _, true, 0.0, true, 45.0);
+	cvarShowBossBlocked = CreateConVar("ff2_boss_show_in_blocked_maps", "1.0", "0-Bosses will not appear in !ff2boss if their config blocked the map. 1-Bosses will appear in !ff2boss as a disabled option.", _, true, 0.0, true, 1.0);
 
 	//The following are used in various subplugins
 	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
@@ -6225,7 +6227,10 @@ public Action Command_SetMyBoss(int client, int args)
 		}
 		else if(MapBlocked[config])
 		{
-			menu.AddItem(boss, bossName, ITEMDRAW_DISABLED);
+            if(cvarShowBossBlocked.BoolValue)
+            {
+                menu.AddItem(boss, bossName, ITEMDRAW_DISABLED);
+            }
 		}
 		else if(KvGetNum(BossKV[config], "nofirst") && (RoundCount<arenaRounds || (RoundCount==arenaRounds && CheckRoundState()!=1)))
 		{

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -2830,6 +2830,33 @@ public void LoadCharacter(const char[] character)
 	FileToKeyValues(BossKV[Specials], config);
 
 	MapBlocked[Specials] = false;
+	if(KvJumpToKey(BossKV[Specials], "map_only"))
+	{
+		char item[6];
+		static char buffer[34];
+		bool shouldBlock = true;
+		for(int size=1; ; size++)
+		{
+			FormatEx(item, sizeof(item), "map%d", size);
+			KvGetString(BossKV[Specials], item, buffer, sizeof(buffer));
+			if(!buffer[0])
+			{
+				if(size==1)
+				{
+					shouldBlock = false;
+				}
+				break;
+			}
+            
+			if(StrContains(currentmap, buffer)>=0)
+			{
+				shouldBlock = false;
+				break;
+			}
+		}
+		MapBlocked[Specials] = shouldBlock;
+	}
+	KvRewind(BossKV[Specials]);
 	if(KvJumpToKey(BossKV[Specials], "map_exclude"))
 	{
 		char item[6];

--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -6017,7 +6017,14 @@ public Action Command_SetMyBoss(int client, int args)
 
 			if(MapBlocked[config])
 			{
-				FReplyToCommand(client, "%t", "deny_map");
+				if(!cvarShowBossBlocked.BoolValue)
+				{
+					FReplyToCommand(client, "%t", "deny_unknown");
+				}
+				else 
+				{
+					FReplyToCommand(client, "%t", "deny_map");
+				}
 				return Plugin_Handled;
 			}
 


### PR DESCRIPTION
I made two changes:

1) Added the _map_only_ setting for bosses. This is the same as _map_exclude_ but with the difference that it'll block the boss in every map that is not in the list.
For example:
```
"map_only"
{
    "map1"  "vsh_military"
    "map2"  "vsh_egyptyspot"
}
```
In that case the boss will **not** be selectable in any map that doesn't starts with _vsh_military_ nor with _vsh_egyptyspot_
Also, _map_exclude_ will always have priority over _map_only_. For example, using the same _map_only_ above with this _map_exclude_ in the same boss:
```
"map_exclude"
{
    "map1"  "vsh_egyptyspot_b5"
}
```
Will cause the boss being selectable in every version of _vsh_egyptyspot_ except for the b5 one.

Naturally, if _map_only_ is missing or it doesn't has any _mapX_ item, the boss will be **unlocked** in every map.

**Explanation**: This feature is for facilitate the exclusive/special bosses in certain maps without having to put every map from the server in _map_exclude_

2) Added _ff2_boss_show_in_blocked_maps_ Cvar (I'm not sure if that is the best name though): This Boolean cvar is for showing/hiding the boss when it's blocked in a map. If its value is 0, the boss will not appear in !ff2boss menu when it's blocked, while if it's 1 (default), the boss will appear as a disabled (white) option in that menu.

If a user tries to select the boss directly from the command (i.e using `!ff2boss BossName`), the command will respond with _deny_map_ translation.

**Explanation**: This Cvar helps when there are secrets bosses for certain maps (for example, anime-based bosses in anime-based maps) that the server owners want to hide from users.